### PR TITLE
[MSVC] work-around for compile time issue 102513

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1406,6 +1406,10 @@ bool handleFixedPointOverflow(InterpState &S, CodePtr OpPC,
   return S.noteUndefinedBehavior();
 }
 
+// https://github.com/llvm/llvm-project/issues/102513
+#if defined(_WIN32) && !defined(__clang__) && !defined(NDEBUG)
+#pragma optimize("", off)
+#endif
 bool Interpret(InterpState &S, APValue &Result) {
   // The current stack frame when we started Interpret().
   // This is being used by the ops to determine wheter
@@ -1430,6 +1434,10 @@ bool Interpret(InterpState &S, APValue &Result) {
     }
   }
 }
+// https://github.com/llvm/llvm-project/issues/102513
+#if defined (_MSC_VER)
+#pragma optimize("", on)
+#endif
 
 } // namespace interp
 } // namespace clang


### PR DESCRIPTION
Disable optimizations when building with Microsoft's compiler as it has a bug that causes excessive build times. We do this only when NDEBUG is not defined on the assumption that building without asserts indicates that a user is strongly invested in runtime performance.

Partially addresses: https://github.com/llvm/llvm-project/issues/102513.

Once the bug is addressed in the Microsoft compiler this can be removed.