### PR TITLE
DTLTO: use simpler JSON format and address remaining review comments

### DIFF
--- a/llvm/docs/DTLTO.rst
+++ b/llvm/docs/DTLTO.rst
@@ -157,29 +157,6 @@ following backend compilation commands with maximum parallelism:
     /usr/bin/clang -O2 -c -fprofile-sample-use=my.prof t2.o  -fthinlto-index=t2.o.thinlto.bc -o t2.native.o \
       -fproc-stat-report=t2.stats.txt
 
-Temporary Files
----------------
-
-During its operation, DTLTO generates temporary files. Temporary files are
-created in the same directory as the linker's output file:
-
-- **JSON Job Description File**:
-
-  - Format: ``<linker output file basename>.<PID>.dist-file.json``
-  - Example: ``dtlto.77380.dist-file.json`` (for output file ``dtlto.elf``).
-
-- **Object Files From Backend Compilations**:
-
-  - Format: ``<Module identifier basename>.<Task>.<PID>.native.o``
-  - Example: ``my.1.77380.native.o`` (for bitcode module ``my.o``).
-
-- **Summary Index Shard Files**:
-
-  - Format: ``<Module identifier basename>.<Task>.<PID>.native.o.thinlto.bc``
-  - Example: ``my.1.77380.native.o.thinlto.bc`` (for bitcode module ``my.o``).
-
-Temporary files are removed by default.
-
 TODOs
 -----
 

--- a/llvm/docs/DTLTO.rst
+++ b/llvm/docs/DTLTO.rst
@@ -11,44 +11,63 @@ DTLTO
 Distributed ThinLTO (DTLTO)
 ===========================
 
-Distributed ThinLTO (DTLTO) facilitates the distribution of backend ThinLTO
-compilations via external distribution systems such as Incredibuild.
+Distributed ThinLTO (DTLTO) enables the distribution of backend ThinLTO
+compilations via external distribution systems, such as Incredibuild, during the
+link step.
 
-The existing method of distributing ThinLTO compilations via separate thin-link,
-backend compilation, and link steps often requires significant changes to the
-user's build process to adopt, as it requires using a build system which can
-handle the dynamic dependencies specified by the index files, such as Bazel.
+DTLTO extends the existing ThinLTO distribution support which uses separate
+*thin-link*, *backend compilation*, and *link* steps. This method is documented
+here:
 
-DTLTO eliminates this need by managing distribution internally within the LLD
-linker during the traditional link step. This allows DTLTO to be used with any
-build process that supports in-process ThinLTO.
+    https://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html
 
-Limitations
------------
+Using the *separate thin-link* approach requires a build system capable of
+handling the dynamic dependencies specified in the individual summary index
+files, such as Bazel. DTLTO removes this requirement, allowing it to be used
+with any build process that supports in-process ThinLTO.
 
-The current implementation of DTLTO has the following limitations:
+The following commands show the steps used for the *separate thin-link*
+approach for a basic example:
 
-- The ThinLTO cache is not supported.
-- Only ELF and COFF platforms are supported.
-- Archives with bitcode members are not supported.
-- Only a very limited set of LTO configurations are currently supported, e.g.,
-  support for basic block sections is not currently available.
+.. code-block:: console
 
-Overview of Operation
----------------------
+    1. clang -flto=thin -O2 t1.c t2.c -c
+    2. clang -flto=thin -O2 t1.o t2.o -fuse-ld=lld -Wl,--thinlto-index-only
+    3. clang -O2 -o t1.native.o t1.o -c -fthinlto-index=t1.o.thinlto.bc
+    4. clang -O2 -o t2.native.o t2.o -c -fthinlto-index=t2.o.thinlto.bc
+    5. clang t1.native.o t2.native.o -o a.out -fuse-ld=lld
 
-For each ThinLTO backend compilation job, LLD:
+With DTLTO, steps 2-5 are performed internally as part of the link step. The
+equivalent DTLTO commands for the above are:
 
-1. Generates the required summary index shard.
-2. Records a list of input and output files.
-3. Constructs a Clang command line to perform the ThinLTO backend compilation.
+.. code-block:: console
 
-This information is supplied, via a JSON file, to a distributor program that
-executes the backend compilations using a distribution system. Upon completion,
-LLD integrates the compiled native object files into the link process.
+    clang -flto=thin -O2 t1.c t2.c -c
+    clang -flto=thin -O2 t1.o t2.o -fuse-ld=lld -fthinlto-distributor=<distributor_process>
 
-The design keeps the details of distribution systems out of the LLVM source
+For DTLTO, LLD prepares the following for each ThinLTO backend compilation job:
+
+- An individual index file and a list of input and output files (corresponds to
+  step 2 above).
+- A Clang command line to perform the ThinLTO backend compilations.
+
+This information is supplied, via a JSON file, to ``distributor_process``, which
+executes the backend compilations using a distribution system (corresponds to
+steps 3 and 4 above). Upon completion, LLD integrates the compiled native object
+files into the link process and completes the link (corresponds to step 5
+above).
+
+This design keeps the details of distribution systems out of the LLVM source
 code.
+
+An example distributor that performs all work on the local system is included in
+the LLVM source tree. To run an example with that distributor, a command line
+such as the following can be used:
+
+.. code-block:: console
+
+   clang -flto=thin -fuse-ld=lld -O2 t1.o t2.o -fthinlto-distributor=$(which python3) \
+     -Xthinlto-distributor=$LLVMSRC/llvm/utils/dtlto/local.py
 
 Distributors
 ------------
@@ -60,161 +79,118 @@ Distributors are programs responsible for:
 3. Blocking execution until all backend compilations are complete.
 
 Distributors must return a non-zero exit code on failure. They can be
-implemented as binaries or in scripting languages, such as Python. An example
-script demonstrating basic local execution is available with the LLVM source
-code.
-
-How Distributors Are Invoked
-----------------------------
+implemented as platform native executables or in a scripting language, such as
+Python.
 
 Clang and LLD provide options to specify a distributor program for managing
-backend compilations. Distributor options and backend compilation options, can
+backend compilations. Distributor options and backend compilation options can
 also be specified. Such options are transparently forwarded.
 
 The backend compilations are currently performed by invoking Clang. For further
 details, refer to:
 
-- Clang documentation: https://clang.llvm.org/docs/ThinLTO.html
-- LLD documentation: https://lld.llvm.org/DTLTO.html
+* Clang documentation: https://clang.llvm.org/docs/ThinLTO.html
+* LLD documentation: https://lld.llvm.org/DTLTO.html
 
 When invoked with a distributor, LLD generates a JSON file describing the
-backend compilation jobs and executes the distributor passing it this file. The
-JSON file provides the following information to the distributor:
-
-- The **command line** to execute the backend compilations.
-   - DTLTO constructs a Clang command line by translating some of the LTO
-     configuration state into Clang options and forwarding options specified
-     by the user.
-
-- **Link output path**.
-   - A string identifying the output to which this LTO invocation will 
-     contribute. Distributors can use this to label build jobs for informational
-     purposes.
-
-- The list of **imports** required for each job.
-   - The per-job list of bitcode files from which importing will occur. This is
-     the same information that is emitted into import files for ThinLTO.
-
-- The **input files** required for each job.
-   - The per-job set of files required for backend compilation, such as bitcode
-     files, summary index files, and profile data.
-
-- The **output files** generated by each job.
-   - The per-job files generated by the backend compilations, such as compiled
-     object files and toolchain metrics.
-
-Temporary Files
----------------
-
-During its operation, DTLTO generates temporary files. Temporary files are
-created in the same directory as the linker's output file and their filenames
-include the stem of the bitcode module, or the output file that the LTO 
-invocation is contributing to, to aid the user in identifying them:
-
-- **JSON Job Description File**:
-    - Format:  `dtlto.<PID>.dist-file.json`
-    - Example: `dtlto.77380.dist-file.json` (for output file `dtlto.elf`).
-
-- **Object Files From Backend Compilations**:
-    - Format:  `<Module ID stem>.<Task>.<PID>.native.o`
-    - Example: `my.1.77380.native.o` (for bitcode module `my.o`).
-
-- **Summary Index Shard Files**:
-    - Format:  `<Module ID stem>.<Task>.<PID>.native.o.thinlto.bc`
-    - Example: `my.1.77380.native.o.thinlto.bc` (for bitcode module `my.o`).
-
-Temporary files are removed, by default, after the backend compilations complete.
+backend compilation jobs and executes the distributor, passing it this file.
 
 JSON Schema
 -----------
 
-Below is an example of a JSON job file for backend compilation of the module
-`dtlto.o`:
+The JSON format is explained by reference to the following example, which
+describes the backend compilation of the modules ``t1.o`` and ``t2.o``:
 
 .. code-block:: json
 
     {
         "common": {
             "linker_output": "dtlto.elf",
-            "linker_version": "LLD 20.0.0",
-            "args": [
-                "/usr/local/clang",
-                "-O3", "-fprofile-sample-use=my.profdata",
-                "-o", ["primary_output", 0],
-                "-c", "-x", "ir", ["primary_input", 0],
-                ["summary_index", "-fthinlto-index=", 0],
-                "--target=x86_64-sie-ps5"
-            ]
+            "args": ["/usr/bin/clang", "-O2", "-c", "-fprofile-sample-use=my.prof"],
+            "inputs": ["my.prof"]
         },
         "jobs": [
             {
-                "primary_input": ["dtlto.o"],
-                "summary_index": ["dtlto.1.51232.native.o.thinlto.bc"],
-                "primary_output": ["dtlto.1.51232.native.o"],
-                "imports": [],
-                "additional_inputs": ["my.profdata"]
+                "args": ["t1.o", "-fthinlto-index=t1.o.thinlto.bc", "-o", "t1.native.o", "-fproc-stat-report=t1.stats.txt"],
+                "inputs": ["t1.o", "t1.o.thinlto.bc"],
+                "outputs": ["t1.native.o", "t1.stats.txt"]
+            },
+            {
+                "args": ["t2.o", "-fthinlto-index=t2.o.thinlto.bc", "-o", "t2.native.o", "-fproc-stat-report=t2.stats.txt"],
+                "inputs": ["t2.o", "t2.o.thinlto.bc"],
+                "outputs": ["t2.native.o", "t2.stats.txt"]
             }
         ]
     }
 
-Key Features of the Schema
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Each entry in the ``jobs`` array represents a single backend compilation job.
+Each job object records its own command-line arguments and input/output files.
+Shared arguments and inputs are defined once in the ``common`` object.
 
-- **Input/Output Paths**: Paths are stored in per-file-type array fields. This
-  allows files to be adjusted, if required, to meet the constraints of the
-  underlying distribution system. For example, a system may only be able to read
-  and write remote files to `C:\\sandbox`. The remote paths used can be adjusted
-  by the distributor for such constraints. Once outputs are back on the local
-  system, the distributor can rename them as required.
+Reserved Entries:
 
+- The first entry in the ``common.args`` array specifies the compiler
+  executable to invoke.
+- The first entry in each job's ``inputs`` array is the bitcode file for the
+  module being compiled.
+- The second entry in each job's ``inputs`` array is the corresponding
+  individual summary index file.
+- The first entry in each job's ``outputs`` array is the primary output object
+  file.
 
-- **Command-Line Template**: Command-line options are stored in a common
-  template to avoid duplication for each job. The template consists of an array
-  of strings and arrays. The arrays are placeholders which reference per-job
-  paths. This allows the remote compiler and its arguments to be changed without
-  updating the distributors.
+Command-line arguments and input/output files are stored separately to allow
+the remote compiler to be changed without updating the distributors, as the
+distributors do not need to understand the details of the compiler command
+line.
 
-Command-Line Expansion Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To generate the backend compilation commands, the common and job-specific
+arguments are concatenated.
 
-To create the backend compilation commands, the command-line template is
-expanded for each job. Placeholders are expanded in the following way: The first
-array element specifies the name of the array field to look in. The remaining
-elements are converted to strings and concatenated. Integers are converted by
-indexing into the specified array.
-
-The example above generates the following backend compilation command for
-`main.o`:
+When consuming the example JSON above, a distributor is expected to issue the
+following backend compilation commands with maximum parallelism:
 
 .. code-block:: console
 
-    /usr/local/clang -O3 -fprofile-sample-use=my.profdata \
-        -o dtlto.1.51232.native.o -c -x ir dtlto.o \
-        -fthinlto-index=dtlto.1.51232.native.o.thinlto.bc --target=x86_64-sie-ps5
+    /usr/bin/clang -O2 -c -fprofile-sample-use=my.prof t1.o -fthinlto-index=t1.o.thinlto.bc -o t1.native.o \
+      -fproc-stat-report=t1.stats.txt
 
-This expansion scheme allows the remote compiler to be changed without updating
-the distributors. For example, if the "args" field in the above example was
-replaced with:
+    /usr/bin/clang -O2 -c -fprofile-sample-use=my.prof t2.o  -fthinlto-index=t2.o.thinlto.bc -o t2.native.o \
+      -fproc-stat-report=t2.stats.txt
 
-.. code-block:: json
+Temporary Files
+---------------
 
-    "args": [
-        "custom-compiler",
-        "-opt-level=2",
-        "-profile-instrument-use-path=my.profdata",
-        "-output", ["primary_output", 0],
-        "-input", ["primary_input", 0],
-        "-thinlto-index", ["summary_index", 0],
-        "-triple", "x86_64-sie-ps5"
-    ]
+During its operation, DTLTO generates temporary files. Temporary files are
+created in the same directory as the linker's output file:
 
-Then distributors can expand the command line without needing to be updated:
+- **JSON Job Description File**:
 
-.. code-block:: console
+  - Format: ``<linker output file basename>.<PID>.dist-file.json``
+  - Example: ``dtlto.77380.dist-file.json`` (for output file ``dtlto.elf``).
 
-    custom-compiler -opt-level=2 -profile-instrument-use-path=my.profdata \
-        -output dtlto.1.51232.native.o -input dtlto.o \
-        -thinlto-index dtlto.1.51232.native.o.thinlto.bc -triple x86_64-sie-ps5
+- **Object Files From Backend Compilations**:
+
+  - Format: ``<Module identifier basename>.<Task>.<PID>.native.o``
+  - Example: ``my.1.77380.native.o`` (for bitcode module ``my.o``).
+
+- **Summary Index Shard Files**:
+
+  - Format: ``<Module identifier basename>.<Task>.<PID>.native.o.thinlto.bc``
+  - Example: ``my.1.77380.native.o.thinlto.bc`` (for bitcode module ``my.o``).
+
+Temporary files are removed by default.
+
+TODOs
+-----
+
+The following features are planned for DTLTO but not yet implemented:
+
+- Support for the ThinLTO in-process cache.
+- Support for platforms other than ELF and COFF.
+- Support for archives with bitcode members.
+- Support for more LTO configurations; only a very limited set of LTO
+  configurations is supported currently, e.g., support for basic block sections
+  is not currently available.
 
 Constraints
 -----------
@@ -222,3 +198,4 @@ Constraints
 - Matching versions of Clang and LLD should be used.
 - The distributor used must support the JSON schema generated by the version of
   LLD in use.
+

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -307,19 +307,27 @@ ThinBackend createInProcessThinBackend(ThreadPoolStrategy Parallelism,
 
 /// This ThinBackend generates the index shards and then runs the individual
 /// backend jobs via an external process. It takes the same parameters as the
-/// InProcessThinBackend, however, these parameters only control the behavior
+/// InProcessThinBackend; however, these parameters only control the behavior
 /// when generating the index files for the modules. Additionally:
 /// LinkerOutputFile is a string that should identify this LTO invocation in
 /// the context of a wider build. It's used for naming to aid the user in
 /// identifying activity related to a specific LTO invocation.
 /// Distributor specifies the path to a process to invoke to manage the backend
-/// jobs execution.
+/// job execution.
+/// DistributorArgs specifies a list of arguments to be applied to the
+/// distributor.
+/// RemoteCompiler specifies the path to a Clang executable to be invoked for
+/// the backend jobs.
+/// RemoteCompilerArgs specifies a list of arguments to be applied to the
+/// backend compilations.
 /// SaveTemps is a debugging tool that prevents temporary files created by this
 /// backend from being cleaned up.
 ThinBackend createOutOfProcessThinBackend(
     ThreadPoolStrategy Parallelism, IndexWriteCallback OnWrite,
     bool ShouldEmitIndexFiles, bool ShouldEmitImportsFiles,
-    StringRef LinkerOutputFile, StringRef Distributor, bool SaveTemps);
+    StringRef LinkerOutputFile, StringRef Distributor,
+    ArrayRef<StringRef> DistributorArgs, StringRef RemoteCompiler,
+    ArrayRef<StringRef> RemoteCompilerArgs, bool SaveTemps);
 
 /// This ThinBackend writes individual module indexes to files, instead of
 /// running the individual backend jobs. This backend is for distributed builds

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -2204,7 +2204,7 @@ class OutOfProcessThinBackend : public CGThinBackend {
   bool SaveTemps;
 
   SmallVector<StringRef, 0> CodegenOptions;
-  DenseSet<StringRef> AdditionalInputs;
+  DenseSet<StringRef> CommonInputs;
 
   // Information specific to individual backend compilation job.
   struct Job {
@@ -2332,7 +2332,7 @@ public:
     if (!C.SampleProfile.empty()) {
       Ops.push_back(
           Saver.save("-fprofile-sample-use=" + Twine(C.SampleProfile)));
-      AdditionalInputs.insert(C.SampleProfile);
+      CommonInputs.insert(C.SampleProfile);
     }
 
     // We don't know which of options will be used by Clang.
@@ -2355,53 +2355,53 @@ public:
 
     json::OStream JOS(OS);
     JOS.object([&]() {
-      // Information common to all jobs note that we use a custom syntax for
-      // referencing by index into the job input and output file arrays.
+      // Information common to all jobs.
       JOS.attributeObject("common", [&]() {
         JOS.attribute("linker_output", LinkerOutputFile);
 
-        // Common command line template.
         JOS.attributeArray("args", [&]() {
           JOS.value(RemoteCompiler);
 
-          // Reference to Job::NativeObjectPath.
-          JOS.value("-o");
-          JOS.value(Array{"primary_output", 0});
-
           JOS.value("-c");
 
-          JOS.value("-x");
-          JOS.value("ir");
-
-          // Reference to Job::ModuleID.
-          JOS.value(Array{"primary_input", 0});
-
-          // Reference to Job::SummaryIndexPath.
-          JOS.value(Array{"summary_index", "-fthinlto-index=", 0});
           JOS.value(Saver.save("--target=" + Twine(Triple)));
 
           for (const auto &A : CodegenOptions)
             JOS.value(A);
         });
+
+        JOS.attribute("inputs", Array(CommonInputs));
       });
+
+      // Per-compilation-job information.
       JOS.attributeArray("jobs", [&]() {
         for (const auto &J : Jobs) {
           assert(J.Task != 0);
+
+          SmallVector<StringRef, 2> Inputs;
+          SmallVector<StringRef, 1> Outputs;
+
           JOS.object([&]() {
-            JOS.attribute("primary_input", Array{J.ModuleID});
-            JOS.attribute("summary_index", Array{J.SummaryIndexPath});
-            JOS.attribute("primary_output", Array{J.NativeObjectPath});
+            JOS.attributeArray("args", [&]() {
+              JOS.value(J.ModuleID);
+              Inputs.push_back(J.ModuleID);
+
+              JOS.value(
+                  Saver.save("-fthinlto-index=" + Twine(J.SummaryIndexPath)));
+              Inputs.push_back(J.SummaryIndexPath);
+
+              JOS.value("-o");
+              JOS.value(J.NativeObjectPath);
+              Outputs.push_back(J.NativeObjectPath);
+            });
 
             // Add the bitcode files from which imports will be made. These do
-            // not appear on the command line but are recorded in the summary
-            // index shard.
-            JOS.attribute("imports", Array(J.ImportFiles));
+            // not explicitly appear on the backend compilation command lines
+            // but are recorded in the summary index shards.
+            llvm::append_range(Inputs, J.ImportFiles);
+            JOS.attribute("inputs", Array(Inputs));
 
-            // Add any input files that are common to each invocation. These
-            // filenames are duplicated in the command line template and in
-            // each of the per job "inputs" array. However, this small amount
-            // of duplication makes the schema simpler.
-            JOS.attribute("additional_inputs", Array(AdditionalInputs));
+            JOS.attribute("outputs", Array(Outputs));
           });
         }
       });

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -94,19 +94,6 @@ extern cl::opt<bool> SupportsHotColdNew;
 
 /// Enable MemProf context disambiguation for thin link.
 extern cl::opt<bool> EnableMemProfContextDisambiguation;
-
-cl::list<std::string> AdditionalThinLTODistributorArgs(
-    "thinlto-distributor-arg",
-    cl::desc("Additional arguments to pass to the ThinLTO distributor"));
-
-cl::opt<std::string> ThinLTORemoteCompiler(
-    "thinlto-remote-compiler",
-    cl::desc("Compiler to invoke for the ThinLTO backend compilations"));
-
-cl::list<std::string>
-    ThinLTORemoteCompilerArgs("thinlto-remote-compiler-arg",
-                              cl::desc("Additional arguments to pass to the "
-                                       "ThinLTO remote compiler"));
 } // namespace llvm
 
 // Computes a unique hash for the Module considering the current list of
@@ -2207,7 +2194,13 @@ class OutOfProcessThinBackend : public CGThinBackend {
   StringSaver Saver{Alloc};
 
   SString LinkerOutputFile;
+
   SString DistributorPath;
+  ArrayRef<StringRef> DistributorArgs;
+
+  SString RemoteCompiler;
+  ArrayRef<StringRef> RemoteCompilerArgs;
+
   bool SaveTemps;
 
   SmallVector<StringRef, 0> CodegenOptions;
@@ -2240,12 +2233,15 @@ public:
       const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
       AddStreamFn AddStream, lto::IndexWriteCallback OnWrite,
       bool ShouldEmitIndexFiles, bool ShouldEmitImportsFiles,
-      StringRef LinkerOutputFile, StringRef Distributor, bool SaveTemps)
+      StringRef LinkerOutputFile, StringRef Distributor,
+      ArrayRef<StringRef> DistributorArgs, StringRef RemoteCompiler,
+      ArrayRef<StringRef> RemoteCompilerArgs, bool SaveTemps)
       : CGThinBackend(Conf, CombinedIndex, ModuleToDefinedGVSummaries,
                       AddStream, OnWrite, ShouldEmitIndexFiles,
                       ShouldEmitImportsFiles, ThinLTOParallelism),
         LinkerOutputFile(LinkerOutputFile), DistributorPath(Distributor),
-        SaveTemps(SaveTemps) {}
+        DistributorArgs(DistributorArgs), RemoteCompiler(RemoteCompiler),
+        RemoteCompilerArgs(RemoteCompilerArgs), SaveTemps(SaveTemps) {}
 
   virtual void setup(unsigned ThinLTONumTasks, unsigned ThinLTOTaskOffset,
                      StringRef Triple) override {
@@ -2343,8 +2339,8 @@ public:
     Ops.push_back("-Wno-unused-command-line-argument");
 
     // Forward any supplied options.
-    if (!ThinLTORemoteCompilerArgs.empty())
-      for (auto &a : ThinLTORemoteCompilerArgs)
+    if (!RemoteCompilerArgs.empty())
+      for (auto &a : RemoteCompilerArgs)
         Ops.push_back(a);
   }
 
@@ -2366,7 +2362,7 @@ public:
 
         // Common command line template.
         JOS.attributeArray("args", [&]() {
-          JOS.value(ThinLTORemoteCompiler);
+          JOS.value(RemoteCompiler);
 
           // Reference to Job::NativeObjectPath.
           JOS.value("-o");
@@ -2454,7 +2450,7 @@ public:
     });
 
     SmallVector<StringRef, 3> Args = {DistributorPath};
-    llvm::append_range(Args, AdditionalThinLTODistributorArgs);
+    llvm::append_range(Args, DistributorArgs);
     Args.push_back(JsonFile);
     std::string ErrMsg;
     if (sys::ExecuteAndWait(Args[0], Args,
@@ -2491,7 +2487,9 @@ public:
 ThinBackend lto::createOutOfProcessThinBackend(
     ThreadPoolStrategy Parallelism, lto::IndexWriteCallback OnWrite,
     bool ShouldEmitIndexFiles, bool ShouldEmitImportsFiles,
-    StringRef LinkerOutputFile, StringRef Distributor, bool SaveTemps) {
+    StringRef LinkerOutputFile, StringRef Distributor,
+    ArrayRef<StringRef> DistributorArgs, StringRef RemoteCompiler,
+    ArrayRef<StringRef> RemoteCompilerArgs, bool SaveTemps) {
   auto Func =
       [=](const Config &Conf, ModuleSummaryIndex &CombinedIndex,
           const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
@@ -2499,7 +2497,8 @@ ThinBackend lto::createOutOfProcessThinBackend(
         return std::make_unique<OutOfProcessThinBackend>(
             Conf, CombinedIndex, Parallelism, ModuleToDefinedGVSummaries,
             AddStream, OnWrite, ShouldEmitIndexFiles, ShouldEmitImportsFiles,
-            LinkerOutputFile, Distributor, SaveTemps);
+            LinkerOutputFile, Distributor, DistributorArgs, RemoteCompiler,
+            RemoteCompilerArgs, SaveTemps);
       };
   return ThinBackend(Func, Parallelism);
 }

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1435,6 +1435,8 @@ Error ThinBackendProc::emitFiles(
 }
 
 namespace {
+// Base class for ThinLTO backends that perform code generation and insert the
+// generated files back into the link.
 class CGThinBackend : public ThinBackendProc {
 protected:
   AddStreamFn AddStream;

--- a/llvm/test/ThinLTO/X86/dtlto/dtlto.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/dtlto.ll
@@ -15,9 +15,7 @@ RUN: mkdir %t/out && cd %t/out
 ; Define a substitution to share the common DTLTO arguments.
 DEFINE: %{command} = llvm-lto2 run ../t1.bc ../t2.bc -o t.o \
 DEFINE:   -dtlto-distributor=%python \
-DEFINE:   -thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
-DEFINE:   -thinlto-distributor-arg=../t1.o \
-DEFINE:   -thinlto-distributor-arg=../t2.o \
+DEFINE:   -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py,../t1.o,../t2.o \
 DEFINE:   -r=../t1.bc,t1,px \
 DEFINE:   -r=../t2.bc,t2,px
 

--- a/llvm/test/ThinLTO/X86/dtlto/imports.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/imports.ll
@@ -10,9 +10,7 @@ RUN: opt -thinlto-bc 1.ll -o 1.bc -O2
 ; of validate.py will cause a failure as it does not create output files.
 DEFINE: %{command} = llvm-lto2 run 0.bc 1.bc -o t.o \
 DEFINE:    -dtlto-distributor=%python \
-DEFINE:    -thinlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
-DEFINE:    -thinlto-distributor-arg=0.bc \
-DEFINE:    -thinlto-distributor-arg=1.bc \
+DEFINE:    -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py,0.bc,1.bc \
 DEFINE:    -thinlto-emit-indexes \
 DEFINE:    -r=0.bc,g,px \
 DEFINE:    -r=1.bc,f,px \

--- a/llvm/test/ThinLTO/X86/dtlto/imports.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/imports.ll
@@ -16,18 +16,21 @@ DEFINE:    -r=0.bc,g,px \
 DEFINE:    -r=1.bc,f,px \
 DEFINE:    -r=1.bc,g
 
-; We expect an import from 0.o into 1.o but no imports into 0.o. Check that the
-; expected input files have been added to the JSON.
+; We expect an import from 0.bc into 1.bc but no imports into 0.bc. Check that
+; the expected input files have been added to the JSON to account for this.
 RUN: not %{command} 2>&1 | FileCheck %s --check-prefixes=INPUTS,ERR
 
-INPUTS:      "primary_input": [
-INPUTS-NEXT:   "0.bc"
+; 1.bc should not appear in the list of inputs for 0.bc.
+INPUTS:      "jobs":
+INPUTS:      "inputs": [
+INPUTS-NEXT:   "0.bc",
+INPUTS-NEXT:   "0.1.[[#]].native.o.thinlto.bc"
 INPUTS-NEXT: ]
-INPUTS:      "imports": []
-INPUTS:      "primary_input": [
-INPUTS-NEXT:   "1.bc"
-INPUTS-NEXT: ]
-INPUTS:      "imports": [
+
+; 0.bc should appear in the list of inputs for 1.bc.
+INPUTS:      "inputs": [
+INPUTS-NEXT:   "1.bc",
+INPUTS-NEXT:   "1.2.[[#]].native.o.thinlto.bc",
 INPUTS-NEXT:   "0.bc"
 INPUTS-NEXT: ]
 

--- a/llvm/test/ThinLTO/X86/dtlto/json.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/json.ll
@@ -21,59 +21,45 @@ CHECK: distributor_args=['--da1=10', '--da2=10']
 ; Check the common object.
 CHECK:      "linker_output": "my.output"
 CHECK:      "args":
-CHECK:      "my_clang.exe"
-CHECK:      "-o"
-CHECK-NEXT: [
-CHECK-NEXT: "primary_output"
-CHECK-NEXT: 0
+CHECK-NEXT: "my_clang.exe"
+CHECK-NEXT: "-c"
+CHECK-NEXT: "--target=x86_64-unknown-linux-gnu"
+CHECK-NEXT: "-O2"
+CHECK-NEXT: "-fpic"
+CHECK-NEXT: "-Wno-unused-command-line-argument"
+CHECK-NEXT: "--rota1=10"
+CHECK-NEXT: "--rota2=20"
 CHECK-NEXT: ]
-CHECK:      "-c"
-CHECK:      "-x"
-CHECK:      "ir"
-CHECK-NEXT: [
-CHECK-NEXT: "primary_input"
-CHECK-NEXT:  0
-CHECK-NEXT: ]
-CHECK:      "summary_index"
-CHECK-NEXT: "-fthinlto-index="
-CHECK-NEXT: 0
-CHECK-NEXT: ]
-CHECK:      "--target=x86_64-unknown-linux-gnu"
-CHECK:      "-O2",
-CHECK:      "-fpic"
-CHECK:      "-Wno-unused-command-line-argument"
-CHECK:      "--rota1=10"
-CHECK:      "--rota2=20"
+CHECK: "inputs": []
 
 ; Check the first job entry.
-CHECK: "jobs":
-CHECK:      "primary_input": [
+CHECK:      "args":
 CHECK-NEXT: "t1.bc"
-CHECK-NEXT: ]
-CHECK:      "summary_index": [
-CHECK-NEXT: "t1.1.[[#]].native.o.thinlto.bc"
-CHECK-NEXT: ]
-CHECK:      "primary_output": [
+CHECK-NEXT: "-fthinlto-index=t1.1.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: "-o"
 CHECK-NEXT: "t1.1.[[#]].native.o"
 CHECK-NEXT: ]
-CHECK:      "imports": [],
-CHECK:      "additional_inputs": []
-CHECK-NEXT: }
+CHECK:      "inputs": [
+CHECK-NEXT: "t1.bc"
+CHECK-NEXT: "t1.1.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: ]
+CHECK:      "outputs": [
+CHECK-NEXT: "t1.1.[[#]].native.o"
+CHECK-NEXT: ]
 
 ; Check the second job entry.
-CHECK-NEXT: {
-CHECK-NEXT: "primary_input": [
+CHECK:      "args": [
 CHECK-NEXT: "t2.bc"
-CHECK-NEXT: ]
-CHECK-NEXT: "summary_index": [
-CHECK-NEXT: "t2.2.[[#]].native.o.thinlto.bc"
-CHECK-NEXT: ]
-CHECK-NEXT: "primary_output": [
+CHECK-NEXT: "-fthinlto-index=t2.2.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: "-o"
 CHECK-NEXT: "t2.2.[[#]].native.o"
 CHECK-NEXT: ]
-CHECK-NEXT: "imports": []
-CHECK-NEXT: "additional_inputs": []
-CHECK-NEXT: }
+CHECK-NEXT: "inputs": [
+CHECK-NEXT: "t2.bc"
+CHECK-NEXT: "t2.2.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: ]
+CHECK-NEXT: "outputs": [
+CHECK-NEXT: "t2.2.[[#]].native.o"
 CHECK-NEXT: ]
 
 ; This check ensures that we have failed for the expected reason.

--- a/llvm/test/ThinLTO/X86/dtlto/json.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/json.ll
@@ -11,12 +11,9 @@ RUN: opt -thinlto-bc t2.ll -o t2.bc
 RUN: not llvm-lto2 run t1.bc t2.bc -o my.output \
 RUN:     -r=t1.bc,t1,px -r=t2.bc,t2,px \
 RUN:     -dtlto-distributor=%python \
-RUN:     -thinlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
-RUN:     -thinlto-remote-compiler=my_clang.exe \
-RUN:     -thinlto-remote-compiler-arg=--rota1=10 \
-RUN:     -thinlto-remote-compiler-arg=--rota2=20 \
-RUN:     -thinlto-distributor-arg=--da1=10 \
-RUN:     -thinlto-distributor-arg=--da2=10 \
+RUN:     -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py,--da1=10,--da2=10 \
+RUN:     -dtlto-compiler=my_clang.exe \
+RUN:     -dtlto-compiler-arg=--rota1=10,--rota2=20 \
 RUN:   2>&1 | FileCheck %s
 
 CHECK: distributor_args=['--da1=10', '--da2=10']

--- a/llvm/test/ThinLTO/X86/dtlto/summary.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/summary.ll
@@ -20,9 +20,7 @@ DEFINE:     -thinlto-emit-indexes
 ; Perform DTLTO.
 RUN: %{command} \
 RUN:     -dtlto-distributor=%python \
-RUN:     -thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
-RUN:     -thinlto-distributor-arg=t1.o \
-RUN:     -thinlto-distributor-arg=t2.o
+RUN:     -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py,t1.o,t2.o
 
 ; Perform ThinLTO.
 RUN: %{command}

--- a/llvm/test/ThinLTO/X86/dtlto/triple.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/triple.ll
@@ -10,7 +10,7 @@ RUN: opt -thinlto-bc t2.ll -o t2.bc
 ; of validate.py will cause a failure as it does not create output files.
 DEFINE: %{command} = llvm-lto2 run -o t.o -save-temps \
 DEFINE:    -dtlto-distributor=%python \
-DEFINE:    -thinlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
+DEFINE:    -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
 DEFINE:    -r=t1.bc,t1,px \
 DEFINE:    -r=t2.bc,t2,px
 

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -100,7 +100,22 @@ static cl::opt<bool>
 static cl::opt<std::string> DTLTODistributor(
     "dtlto-distributor",
     cl::desc("Distributor to use for ThinLTO backend compilations. Specifying "
-             "this activates DTLTO."));
+             "this enables DTLTO."));
+
+static cl::list<std::string> DTLTODistributorArgs(
+    "dtlto-distributor-arg", cl::CommaSeparated,
+    cl::desc("Arguments to pass to the DTLTO distributor process."),
+    cl::value_desc("arg"));
+
+static cl::opt<std::string> DTLTOCompiler(
+    "dtlto-compiler",
+    cl::desc("Compiler to use for DTLTO ThinLTO backend compilations."));
+
+static cl::list<std::string> DTLTOCompilerArgs(
+    "dtlto-compiler-arg", cl::CommaSeparated,
+    cl::desc("Arguments to pass to the remote compiler for backend "
+             "compilations."),
+    cl::value_desc("arg"));
 
 // Default to using all available threads in the system, but using only one
 // thread per core (no SMT).
@@ -352,6 +367,10 @@ static int run(int argc, char **argv) {
   if (ThinLTODistributedIndexes && !DTLTODistributor.empty())
     llvm::errs() << "-thinlto-distributed-indexes cannot be specfied together "
                     "with -dtlto-distributor\n";
+  auto DTLTODistributorArgsSV = llvm::to_vector<0>(llvm::map_range(
+      DTLTODistributorArgs, [](const std::string &S) { return StringRef(S); }));
+  auto DTLTOCompilerArgsSV = llvm::to_vector<0>(llvm::map_range(
+      DTLTOCompilerArgs, [](const std::string &S) { return StringRef(S); }));
 
   ThinBackend Backend;
   if (ThinLTODistributedIndexes)
@@ -363,11 +382,11 @@ static int run(int argc, char **argv) {
                                             /*LinkedObjectsFile=*/nullptr,
                                             /*OnWrite=*/{});
   else if (!DTLTODistributor.empty()) {
-
     Backend = createOutOfProcessThinBackend(
         llvm::heavyweight_hardware_concurrency(Threads),
         /*OnWrite=*/{}, ThinLTOEmitIndexes, ThinLTOEmitImports, OutputFilename,
-        DTLTODistributor, SaveTemps);
+        DTLTODistributor, DTLTODistributorArgsSV, DTLTOCompiler,
+        DTLTOCompilerArgsSV, SaveTemps);
   } else
     Backend = createInProcessThinBackend(
         llvm::heavyweight_hardware_concurrency(Threads),

--- a/llvm/utils/dtlto/local.py
+++ b/llvm/utils/dtlto/local.py
@@ -25,17 +25,4 @@ if __name__ == "__main__":
 
     # Iterate over the jobs and execute the codegen tool.
     for job in data["jobs"]:
-        jobargs = []
-        for arg in data["common"]["args"]:
-            if isinstance(arg, list):
-                # arg is a "template", into which an external filename is to be
-                # inserted. The first element of arg names an array of strings
-                # in the job. The remaining elements of arg are either indices
-                # into the array or literal strings.
-                files, rest = job[arg[0]], arg[1:]
-                jobargs.append(
-                    "".join(files[x] if isinstance(x, int) else x for x in rest)
-                )
-            else:
-                jobargs.append(arg)
-        subprocess.check_call(jobargs)
+        subprocess.check_call(data["common"]["args"] + job["args"])

--- a/llvm/utils/dtlto/mock.py
+++ b/llvm/utils/dtlto/mock.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # Iterate over the jobs and create the output
     # files by copying over the supplied input files.
     for job_index, job in enumerate(data["jobs"]):
-        shutil.copy(input_files[job_index], job["primary_output"][0])
+        shutil.copy(input_files[job_index], job["outputs"][0])
 
     # Check the format of the JSON.
     validate.validate(data)

--- a/llvm/utils/dtlto/validate.py
+++ b/llvm/utils/dtlto/validate.py
@@ -11,7 +11,7 @@ Arguments:
     - <json_file> : JSON file describing the DTLTO jobs.
 
 The script does the following:
-    1. Prints the supplied CLI arguments.
+    1. Prints the supplied distributor arguments.
     2. Loads the JSON file.
     3. Pretty prints the JSON.
     4. Validates the structure and required fields.
@@ -36,24 +36,11 @@ def validate(jdoc):
     args = take(jdoc, "common.args")
     assert type(args) is list
     assert len(args) > 0
+    assert all(type(i) is str for i in args)
 
-    def validate_reference(a):
-        for j in jdoc["jobs"]:
-            for x in a[1:]:
-                if type(x) is int:
-                    if a[0] not in j or x >= len(j[a[0]]):
-                        return False
-        return True
-
-    for a in args:
-        assert type(a) is str or (
-            type(a) is list
-            and len(a) >= 2
-            and type(a[0]) is str
-            and all(type(x) in (str, int) for x in a[1:])
-            and any(type(x) is int for x in a[1:])
-            and validate_reference(a)
-        )
+    inputs = take(jdoc, "common.inputs")
+    assert type(inputs) is list
+    assert all(type(i) is str for i in inputs)
 
     assert len(take(jdoc, "common")) == 0
 
@@ -62,18 +49,9 @@ def validate(jdoc):
     for j in jobs:
         assert type(j) is dict
 
-        # Mandatory job attributes.
-        for attr in ("primary_input", "primary_output", "summary_index"):
+        for attr, min_size in (("args", 0), ("inputs", 2), ("outputs", 1)):
             array = take(j, attr)
-            assert type(array) is list
-            assert len(array) == 1
-            assert type(array[0]) is str
-
-        # Optional job attributes.
-        for attr in ("additional_inputs", "additional_outputs", "imports"):
-            array = take(j, attr)
-            if array is KeyError:
-                continue
+            assert len(array) >= min_size
             assert type(array) is list
             assert all(type(a) is str for a in array)
 
@@ -86,6 +64,7 @@ if __name__ == "__main__":
     json_arg = Path(sys.argv[-1])
     distributor_args = sys.argv[1:-1]
 
+    # Print the supplied distributor arguments.
     print(f"{distributor_args=}")
 
     # Load the DTLTO information from the input JSON file.


### PR DESCRIPTION
Update to a simpler JSON format, address the remaining review comments, and revamp the documentation.

I have tried to address all the documentation comments that have been made. In particular I have tried to present DTLTO by way of comparison to the existing Bazel-style ThinLTO distribution as reviewers indicated that was helpful in understanding the feature.