### PR TITLE
[DTLTO] Normalize Windows 8.3 short paths to long form 

### DIFF
--- a/cross-project-tests/CMakeLists.txt
+++ b/cross-project-tests/CMakeLists.txt
@@ -19,11 +19,12 @@ set(CROSS_PROJECT_TEST_DEPS
   FileCheck
   check-gdb-llvm-support
   count
-  llvm-dwarfdump
+  llvm-ar
   llvm-config
+  llvm-dwarfdump
   llvm-objdump
-  split-file
   not
+  split-file
   )
 
 if ("clang" IN_LIST LLVM_ENABLE_PROJECTS)
@@ -92,6 +93,13 @@ add_lit_testsuite(check-cross-amdgpu "Running AMDGPU cross-project tests"
   ${CMAKE_CURRENT_BINARY_DIR}/amdgpu
   EXCLUDE_FROM_CHECK_ALL
   DEPENDS clang
+  )
+
+# DTLTO tests.
+add_lit_testsuite(check-cross-dtlto "Running DTLTO cross-project tests"
+  ${CMAKE_CURRENT_BINARY_DIR}/dtlto
+  EXCLUDE_FROM_CHECK_ALL
+  DEPENDS ${CROSS_PROJECT_TEST_DEPS}
   )
 
 # Add check-cross-project-* targets.

--- a/cross-project-tests/dtlto/README.md
+++ b/cross-project-tests/dtlto/README.md
@@ -1,0 +1,3 @@
+Tests for DTLTO (Integrated Distributed ThinLTO) functionality.
+
+These are integration tests as DTLTO invokes `clang` for code-generation.

--- a/cross-project-tests/dtlto/archive-thin.test
+++ b/cross-project-tests/dtlto/archive-thin.test
@@ -1,0 +1,65 @@
+# REQUIRES: x86-registered-target,ld.lld,llvm-ar
+
+# Test that a DTLTO link succeeds and outputs the expected set of files
+# correctly when thin archives are present.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+RUN: %clang --target=x86_64-linux-gnu -flto=thin -c \
+RUN:   foo.c bar.c dog.c cat.c _start.c
+
+RUN: llvm-ar rcs foo.a foo.o --thin
+# Create this bitcode thin archive in a subdirectory to test the expansion of
+# the path to a bitcode file that is referenced using "..", e.g., in this case
+# "../bar.o".
+RUN: mkdir lib
+RUN: llvm-ar rcs lib/bar.a bar.o --thin
+# Create this bitcode thin archive with an absolute path entry containing "..".
+RUN: llvm-ar rcs dog.a %t/lib/../dog.o --thin
+RUN: llvm-ar rcs cat.a cat.o --thin
+RUN: llvm-ar rcs _start.a _start.o --thin
+
+RUN: mkdir %t/out && cd %t/out
+
+RUN: ld.lld %t/foo.a %t/lib/bar.a ../_start.a %t/cat.a \
+RUN:   --whole-archive ../dog.a \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/local.py \
+RUN:   --thinlto-remote-compiler=%clang \
+RUN:   --save-temps
+
+# Check that the required output files have been created.
+RUN: ls | FileCheck %s --check-prefix=OUTPUTS \
+RUN:     --implicit-check-not=cat --implicit-check-not=foo
+
+# JSON jobs description.
+OUTPUTS-DAG: a.[[PID:[a-zA-Z0-9_]+]].dist-file.json
+
+# Individual summary index files.
+OUTPUTS-DAG:    dog.1.[[PID]].native.o.thinlto.bc{{$}}
+OUTPUTS-DAG: _start.2.[[PID]].native.o.thinlto.bc{{$}}
+OUTPUTS-DAG:    bar.3.[[PID]].native.o.thinlto.bc{{$}}
+
+# Native output object files.
+OUTPUTS-DAG:    dog.1.[[PID]].native.o{{$}}
+OUTPUTS-DAG: _start.2.[[PID]].native.o{{$}}
+OUTPUTS-DAG:    bar.3.[[PID]].native.o{{$}}
+
+#--- foo.c
+__attribute__((retain)) void foo() {}
+
+#--- bar.c
+extern void foo();
+__attribute__((retain)) void bar() { foo(); }
+
+#--- dog.c
+__attribute__((retain)) void dog() {}
+
+#--- cat.c
+__attribute__((retain)) void cat() {}
+
+#--- _start.c
+extern void bar();
+__attribute__((retain)) void _start() {
+  bar();
+}
+

--- a/cross-project-tests/dtlto/dtlto.c
+++ b/cross-project-tests/dtlto/dtlto.c
@@ -1,0 +1,35 @@
+// REQUIRES: x86-registered-target,ld.lld
+
+/// Simple test that DTLTO works with a single input bitcode file and that
+/// --save-temps can be applied to the remote compilation.
+// RUN: rm -rf %t && mkdir %t && cd %t
+
+// RUN: %clang --target=x86_64-linux-gnu -c -flto=thin %s
+
+// RUN: ld.lld dtlto.o \
+// RUN:   --thinlto-distributor=%python \
+// RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/local.py \
+// RUN:   --thinlto-remote-compiler=%clang \
+// RUN:   --thinlto-remote-compiler-arg=--save-temps
+
+/// Check that the required output files have been created.
+// RUN: ls | count 10
+// RUN: ls | FileCheck %s
+
+/// Produced by the bitcode compilation.
+// CHECK-DAG: {{^}}dtlto.o{{$}}
+
+/// Linked ELF.
+// CHECK-DAG: {{^}}a.out{{$}}
+
+/// --save-temps output for the backend compilation.
+// CHECK-DAG: {{^}}dtlto.s{{$}}
+// CHECK-DAG: {{^}}dtlto.s.0.preopt.bc{{$}}
+// CHECK-DAG: {{^}}dtlto.s.1.promote.bc{{$}}
+// CHECK-DAG: {{^}}dtlto.s.2.internalize.bc{{$}}
+// CHECK-DAG: {{^}}dtlto.s.3.import.bc{{$}}
+// CHECK-DAG: {{^}}dtlto.s.4.opt.bc{{$}}
+// CHECK-DAG: {{^}}dtlto.s.5.precodegen.bc{{$}}
+// CHECK-DAG: {{^}}dtlto.s.resolution.txt{{$}}
+
+int _start() { return 0; }

--- a/cross-project-tests/dtlto/lit.local.cfg
+++ b/cross-project-tests/dtlto/lit.local.cfg
@@ -1,0 +1,2 @@
+if "clang" not in config.available_features:
+    config.unsupported = True

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -6,12 +6,10 @@
 
 RUN: rm -rf %t && split-file %s %t && cd %t
 
-# Create an archive to confirm unpacked member paths are expanded.
 RUN: prospero-clang --target=x86_64-linux-gnu -c start.c f.c -flto=thin -O2
-RUN: prospero-llvm-ar rcs libf.a f.o --thin
 
 RUN: %python in-tilde-dir.py \
-RUN:   ld.lld start.o libf.a -o start.elf \
+RUN:   ld.lld start.o f.o -o start.elf \
 RUN:     --thinlto-distributor=%python \
 RUN:     --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/local.py \
 RUN:     --thinlto-remote-compiler=%clang \
@@ -39,14 +37,13 @@ int f();
 int _start() { return f(); }
 
 #--- in-tilde-dir.py
-import os, shutil, sys, uuid, subprocess
-from pathlib import Path
+import os, shutil, sys, uuid, subprocess; from pathlib import Path
 
 temp = Path(os.environ['TEMP'])
 assert temp.is_dir()
 
 # Copy the CWD to a unique directory inside TEMP and determine its 8.3 form.
-# TEMP is likely to be on a drive that supports long+short paths.
+# TEMP is likely to be on a drive that supports 8.3 form paths.
 d = (temp / str(uuid.uuid4()) / 'veryverylong').resolve()
 d83 = d.parent / (d.name[:6] + '~1')
 d.parent.mkdir(parents=True)

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -1,0 +1,65 @@
+# REQUIRES: x86-registered-target,ld.lld,llvm-ar
+
+# Check that any shortened "8.3" paths containing '~' characters are expanded,
+# and their path seperators changed to Winodws style ones, prior to being passed
+# to SN-DBS during DTLTO.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+# Create an archive to confirm unpacked member paths are expanded.
+RUN: prospero-clang --target=x86_64-linux-gnu -c start.c f.c -flto=thin -O2
+RUN: prospero-llvm-ar rcs libf.a f.o --thin
+
+RUN: %python in-tilde-dir.py \
+RUN:   ld.lld start.o libf.a -o start.elf \
+RUN:     --thinlto-distributor=%python \
+RUN:     --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/local.py \
+RUN:     --thinlto-remote-compiler=%clang \
+RUN:     --save-temps
+
+# Ensure that cross-module importing occurred. Cross-module importing is somewhat
+# fragile - e.g. it requires amenable code and compilation with -O2 or above.
+# It's important that importing happens for this test case, as the paths to
+# imported-from modules are recorded in the ThinLTO metadata.
+RUN: prospero-llvm-objdump -d start.elf | tee d.txt | FileCheck %s --check-prefix=IMPORT
+IMPORT: <_start>:
+IMPORT: jmp 0x{{[0-9A-F]+}} <_start>
+IMPORT: <f>:
+IMPORT-NEXT: jmp 0x{{[0-9A-F]+}} <f>
+
+RUN: FileCheck --input-file start.*.dist-file.json %s --check-prefix=TILDE
+TILDE-NOT: ~
+
+#--- f.c
+int _start();
+int f() { return _start(); }
+
+#--- start.c
+int f();
+int _start() { return f(); }
+
+#--- in-tilde-dir.py
+import os, shutil, sys, uuid, subprocess
+from pathlib import Path
+
+temp = Path(os.environ['TEMP'])
+assert temp.is_dir()
+
+# Copy the CWD to a unique directory inside TEMP and determine its 8.3 form.
+# TEMP is likely to be on a drive that supports long+short paths.
+d = (temp / str(uuid.uuid4()) / 'veryverylong').resolve()
+d83 = d.parent / (d.name[:6] + '~1')
+d.parent.mkdir(parents=True)
+try:
+    shutil.copytree(Path.cwd(), d)
+
+    # Replace the arguments of the command that name files with equivalents in
+    # our temp directory, prefixed with the 8.3 form.
+    cmd = [a if not Path(a).is_file() else str(d83/a) \
+           for a in sys.argv[1:]]
+    print(cmd)
+
+    sys.exit(subprocess.run(cmd).returncode)
+
+finally:
+    shutil.rmtree(d.parent)

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -1,4 +1,4 @@
-# REQUIRES: x86-registered-target,ld.lld,llvm-ar
+# REQUIRES: x86-registered-target,ld.lld,llvm-ar,system-windows,shortpaths
 
 # Check that any shortened "8.3" paths containing '~' characters are expanded,
 # and their path seperators changed to Windows style ones, prior to being passed

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -2,7 +2,7 @@
 
 # Check that any shortened "8.3" paths containing '~' characters are expanded,
 # and their path seperators changed to Windows style ones, prior to being passed
-# to SN-DBS during DTLTO.
+# to the distributor.
 
 RUN: rm -rf %t && split-file %s %t && cd %t
 

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -50,13 +50,20 @@ def get_short_path(p):
         return b.value
     raise ctypes.WinError()
 
+def replace_drive_with_admin_share(path: str) -> str:
+    p = Path(path).resolve()
+    if p.drive and len(p.drive) == 2 and p.drive[1] == ':':
+        share = f"\\\\localhost\\{p.drive[0]}$"
+        return os.path.join(share, *p.parts[1:])
+    return str(p)
+
 temp = Path(os.environ['TEMP'])
 assert temp.is_dir()
 
 # Copy the CWD to a unique directory inside TEMP and ensure that one of the path
 # components is long enough to have a distinct 8.3 form.
 # TEMP is likely to be on a drive that supports 8.3 form paths.
-d = (temp / str(uuid.uuid4()) / 'veryverylong').resolve()
+d = (temp / str(uuid.uuid4()) / 'veryverylong123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789').resolve()
 d.parent.mkdir(parents=True)
 try:
     shutil.copytree(Path.cwd(), d)
@@ -64,9 +71,10 @@ try:
     # Replace the arguments of the command that name files with equivalents in
     # our temp directory, prefixed with the 8.3 form.
     cmd = [a if Path(a).is_absolute() or not (d/a).is_file()
-              else get_short_path(d/a) for a in sys.argv[1:]]
+              else replace_drive_with_admin_share(get_short_path(d/a)) for a in sys.argv[1:]]
 
     print(cmd)
+    #assert(cmd == "bob!")
 
     sys.exit(subprocess.run(cmd).returncode)
 

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -1,4 +1,4 @@
-# REQUIRES: x86-registered-target,ld.lld,llvm-ar,system-windows,shortpaths
+# REQUIRES: x86-registered-target,ld.lld,llvm-ar,system-windows,tempshortpaths
 
 # Check that any shortened "8.3" paths containing '~' characters are expanded,
 # and their path seperators changed to Windows style ones, prior to being passed
@@ -8,7 +8,7 @@ RUN: rm -rf %t && split-file %s %t && cd %t
 
 RUN: prospero-clang --target=x86_64-linux-gnu -c start.c f.c -flto=thin -O2
 
-RUN: %python in-tilde-dir.py \
+RUN: %python in-83-dir.py \
 RUN:   ld.lld start.o f.o -o start.elf \
 RUN:     --thinlto-distributor=%python \
 RUN:     --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/local.py \
@@ -36,24 +36,36 @@ int f() { return _start(); }
 int f();
 int _start() { return f(); }
 
-#--- in-tilde-dir.py
+#--- in-83-dir.py
 import os, shutil, sys, uuid, subprocess; from pathlib import Path
+import ctypes; from ctypes import wintypes
+
+def get_short_path(p):
+    g = ctypes.windll.kernel32.GetShortPathNameW
+    g.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    g.restype = wintypes.DWORD
+    n = g(os.path.abspath(p), None, 0) # First call gets required buffer size.
+    b = ctypes.create_unicode_buffer(n)
+    if g(os.path.abspath(p), b, n): # Second call fills buffer.
+        return b.value
+    raise ctypes.WinError()
 
 temp = Path(os.environ['TEMP'])
 assert temp.is_dir()
 
-# Copy the CWD to a unique directory inside TEMP and determine its 8.3 form.
+# Copy the CWD to a unique directory inside TEMP and ensure that one of the path
+# components is long enough to have a distinct 8.3 form.
 # TEMP is likely to be on a drive that supports 8.3 form paths.
 d = (temp / str(uuid.uuid4()) / 'veryverylong').resolve()
-d83 = d.parent / (d.name[:6] + '~1')
 d.parent.mkdir(parents=True)
 try:
     shutil.copytree(Path.cwd(), d)
 
     # Replace the arguments of the command that name files with equivalents in
     # our temp directory, prefixed with the 8.3 form.
-    cmd = [a if not Path(a).is_file() else str(d83/a) \
-           for a in sys.argv[1:]]
+    cmd = [a if Path(a).is_absolute() or not (d/a).is_file()
+              else get_short_path(d/a) for a in sys.argv[1:]]
+
     print(cmd)
 
     sys.exit(subprocess.run(cmd).returncode)

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -50,20 +50,13 @@ def get_short_path(p):
         return b.value
     raise ctypes.WinError()
 
-def replace_drive_with_admin_share(path: str) -> str:
-    p = Path(path).resolve()
-    if p.drive and len(p.drive) == 2 and p.drive[1] == ':':
-        share = f"\\\\localhost\\{p.drive[0]}$"
-        return os.path.join(share, *p.parts[1:])
-    return str(p)
-
 temp = Path(os.environ['TEMP'])
 assert temp.is_dir()
 
 # Copy the CWD to a unique directory inside TEMP and ensure that one of the path
 # components is long enough to have a distinct 8.3 form.
 # TEMP is likely to be on a drive that supports 8.3 form paths.
-d = (temp / str(uuid.uuid4()) / 'veryverylong123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789').resolve()
+d = (temp / str(uuid.uuid4()) / 'veryverylong').resolve()
 d.parent.mkdir(parents=True)
 try:
     shutil.copytree(Path.cwd(), d)
@@ -71,10 +64,9 @@ try:
     # Replace the arguments of the command that name files with equivalents in
     # our temp directory, prefixed with the 8.3 form.
     cmd = [a if Path(a).is_absolute() or not (d/a).is_file()
-              else replace_drive_with_admin_share(get_short_path(d/a)) for a in sys.argv[1:]]
+              else get_short_path(d/a) for a in sys.argv[1:]]
 
     print(cmd)
-    #assert(cmd == "bob!")
 
     sys.exit(subprocess.run(cmd).returncode)
 

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -1,7 +1,7 @@
 # REQUIRES: x86-registered-target,ld.lld,llvm-ar
 
 # Check that any shortened "8.3" paths containing '~' characters are expanded,
-# and their path seperators changed to Winodws style ones, prior to being passed
+# and their path seperators changed to Windows style ones, prior to being passed
 # to SN-DBS during DTLTO.
 
 RUN: rm -rf %t && split-file %s %t && cd %t

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -37,34 +37,40 @@ int f();
 int _start() { return f(); }
 
 #--- in-83-dir.py
-import os, shutil, sys, uuid, subprocess; from pathlib import Path
-import ctypes; from ctypes import wintypes
+import os, shutil, sys, uuid, subprocess
+from pathlib import Path
+import ctypes
+from ctypes import wintypes
+
 
 def get_short_path(p):
     g = ctypes.windll.kernel32.GetShortPathNameW
     g.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
     g.restype = wintypes.DWORD
-    n = g(os.path.abspath(p), None, 0) # First call gets required buffer size.
+    n = g(os.path.abspath(p), None, 0)  # First call gets required buffer size.
     b = ctypes.create_unicode_buffer(n)
-    if g(os.path.abspath(p), b, n): # Second call fills buffer.
+    if g(os.path.abspath(p), b, n):  # Second call fills buffer.
         return b.value
     raise ctypes.WinError()
 
-temp = Path(os.environ['TEMP'])
+
+temp = Path(os.environ["TEMP"])
 assert temp.is_dir()
 
 # Copy the CWD to a unique directory inside TEMP and ensure that one of the path
 # components is long enough to have a distinct 8.3 form.
 # TEMP is likely to be on a drive that supports 8.3 form paths.
-d = (temp / str(uuid.uuid4()) / 'veryverylong').resolve()
+d = (temp / str(uuid.uuid4()) / "veryverylong").resolve()
 d.parent.mkdir(parents=True)
 try:
     shutil.copytree(Path.cwd(), d)
 
     # Replace the arguments of the command that name files with equivalents in
     # our temp directory, prefixed with the 8.3 form.
-    cmd = [a if Path(a).is_absolute() or not (d/a).is_file()
-              else get_short_path(d/a) for a in sys.argv[1:]]
+    cmd = [
+        a if Path(a).is_absolute() or not (d / a).is_file() else get_short_path(d / a)
+        for a in sys.argv[1:]
+    ]
 
     print(cmd)
 

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -21,7 +21,7 @@ RUN:     --save-temps
 # fragile - e.g. it requires amenable code and compilation with -O2 or above.
 # It's important that importing happens for this test case, as the paths to
 # imported-from modules are recorded in the ThinLTO metadata.
-RUN: prospero-llvm-objdump -d start.elf | tee d.txt | FileCheck %s --check-prefix=IMPORT
+RUN: prospero-llvm-objdump -d start.elf | FileCheck %s --check-prefix=IMPORT
 IMPORT: <_start>:
 IMPORT: jmp 0x{{[0-9A-F]+}} <_start>
 IMPORT: <f>:

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -19,7 +19,7 @@ config.name = "cross-project-tests"
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = [".c", ".cl", ".cpp", ".m"]
+config.suffixes = [".c", ".cl", ".cpp", ".m", ".test"]
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
@@ -107,6 +107,8 @@ lldb_path = llvm_config.use_llvm_tool("lldb", search_env="LLDB")
 if lldb_path is not None:
     config.available_features.add("lldb")
 
+if llvm_config.use_llvm_tool("llvm-ar"):
+    config.available_features.add("llvm-ar")
 
 def configure_dexter_substitutions():
     """Configure substitutions for host platform and return list of dependencies"""

--- a/cross-project-tests/lit.site.cfg.py.in
+++ b/cross-project-tests/lit.site.cfg.py.in
@@ -26,3 +26,36 @@ lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CROSS_PROJECT_TESTS_SOURCE_DIR@/lit.cfg.py")
+
+def is_short_names_enabled(path_utf8: str) -> bool:
+    import os, ctypes; from ctypes import wintypes
+
+    k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    try:
+        fn = k32.AreShortNamesEnabled
+        fn.restype = wintypes.BOOL
+        fn.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.BOOL)]
+    except AttributeError:
+        return False
+
+    path_w = ctypes.create_unicode_buffer(os.path.abspath(path_utf8), 260)
+    vol_w = ctypes.create_unicode_buffer(260)
+    if not k32.GetVolumePathNameW(path_w, vol_w, 260):
+        return False
+
+    # 0x80000000 = GENERIC_READ
+    # 0x7        = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+    # 3          = OPEN_EXISTING
+    # 0x02000000 = FILE_FLAG_BACKUP_SEMANTICS
+    handle = k32.CreateFileW(
+        vol_w, 0x80000000, 0x7, None, 3, 0x02000000, None)
+    if handle == ctypes.c_void_p(-1).value:
+        return False
+
+    res = wintypes.BOOL()
+    ok = fn(handle, ctypes.byref(res))
+    k32.CloseHandle(handle)
+    return bool(ok and res.value)
+
+if os.name == "nt" and is_short_names_enabled(config.environment.get('TEMP')):
+    config.available_features.add('shortpaths')

--- a/cross-project-tests/lit.site.cfg.py.in
+++ b/cross-project-tests/lit.site.cfg.py.in
@@ -50,4 +50,4 @@ def are_short_names_enabled(p):
     return bool(ok and r.value)
 
 if os.name == "nt" and are_short_names_enabled(config.environment.get('TEMP')):
-    config.available_features.add('shortpaths')
+    config.available_features.add('tempshortpaths')

--- a/cross-project-tests/lit.site.cfg.py.in
+++ b/cross-project-tests/lit.site.cfg.py.in
@@ -1,7 +1,8 @@
 @LIT_SITE_CFG_IN_HEADER@
 
-import sys
+import shutil, sys, os, uuid
 import lit.util
+from pathlib import Path
 
 config.targets_to_build = "@TARGETS_TO_BUILD@".split()
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
@@ -22,32 +23,21 @@ config.mlir_src_root = "@MLIR_SOURCE_DIR@"
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 
 import lit.llvm
+
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CROSS_PROJECT_TESTS_SOURCE_DIR@/lit.cfg.py")
 
-def are_short_names_enabled(p):
-    import os, ctypes; from ctypes import wintypes; from pathlib import Path
-    try:
-        fn = ctypes.WinDLL("kernel32", use_last_error=True).AreShortNamesEnabled
-        fn.restype = wintypes.BOOL
-        fn.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.BOOL)]
-    except AttributeError:
-        return False
-    # 0x80000000 = GENERIC_READ
-    # 0x7        = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
-    # 3          = OPEN_EXISTING
-    # 0x02000000 = FILE_FLAG_BACKUP_SEMANTICS
-    h = ctypes.windll.kernel32.CreateFileW(
-        str(Path(p).resolve().anchor),
-        0x80000000, 0x7, None, 3, 0x02000000, None)
-    if h == ctypes.c_void_p(-1).value:
-        return False
-    r = wintypes.BOOL();
-    ok = fn(h, ctypes.byref(r))
-    ctypes.windll.kernel32.CloseHandle(h)
-    return bool(ok and r.value)
 
-if os.name == "nt" and are_short_names_enabled(config.environment.get('TEMP')):
-    config.available_features.add('tempshortpaths')
+def are_short_names_enabled(path):
+    d = Path(path) / str(uuid.uuid4()) / "verylongdir"
+    d.mkdir(parents=True)
+    try:
+        return (d.parent / "verylo~1").exists()
+    finally:
+        shutil.rmtree(d.parent)
+
+
+if os.name == "nt" and are_short_names_enabled(config.environment.get("TEMP")):
+    config.available_features.add("tempshortpaths")

--- a/cross-project-tests/lit.site.cfg.py.in
+++ b/cross-project-tests/lit.site.cfg.py.in
@@ -27,35 +27,27 @@ lit.llvm.initialize(lit_config, config)
 # Let the main config do the real work.
 lit_config.load_config(config, "@CROSS_PROJECT_TESTS_SOURCE_DIR@/lit.cfg.py")
 
-def is_short_names_enabled(path_utf8: str) -> bool:
-    import os, ctypes; from ctypes import wintypes
-
-    k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+def are_short_names_enabled(p):
+    import os, ctypes; from ctypes import wintypes; from pathlib import Path
     try:
-        fn = k32.AreShortNamesEnabled
+        fn = ctypes.WinDLL("kernel32", use_last_error=True).AreShortNamesEnabled
         fn.restype = wintypes.BOOL
         fn.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.BOOL)]
     except AttributeError:
         return False
-
-    path_w = ctypes.create_unicode_buffer(os.path.abspath(path_utf8), 260)
-    vol_w = ctypes.create_unicode_buffer(260)
-    if not k32.GetVolumePathNameW(path_w, vol_w, 260):
-        return False
-
     # 0x80000000 = GENERIC_READ
     # 0x7        = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
     # 3          = OPEN_EXISTING
     # 0x02000000 = FILE_FLAG_BACKUP_SEMANTICS
-    handle = k32.CreateFileW(
-        vol_w, 0x80000000, 0x7, None, 3, 0x02000000, None)
-    if handle == ctypes.c_void_p(-1).value:
+    h = ctypes.windll.kernel32.CreateFileW(
+        str(Path(p).resolve().anchor),
+        0x80000000, 0x7, None, 3, 0x02000000, None)
+    if h == ctypes.c_void_p(-1).value:
         return False
+    r = wintypes.BOOL();
+    ok = fn(h, ctypes.byref(r))
+    ctypes.windll.kernel32.CloseHandle(h)
+    return bool(ok and r.value)
 
-    res = wintypes.BOOL()
-    ok = fn(handle, ctypes.byref(res))
-    k32.CloseHandle(handle)
-    return bool(ok and res.value)
-
-if os.name == "nt" and is_short_names_enabled(config.environment.get('TEMP')):
+if os.name == "nt" and are_short_names_enabled(config.environment.get('TEMP')):
     config.available_features.add('shortpaths')

--- a/lld/Common/Filesystem.cpp
+++ b/lld/Common/Filesystem.cpp
@@ -22,6 +22,12 @@
 #include <unistd.h>
 #endif
 #include <thread>
+#if defined(_WIN32)
+#include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/Windows/WindowsSupport.h"
+#include "llvm/Support/WindowsError.h"
+#include <io.h>
+#endif
 
 using namespace llvm;
 using namespace lld;
@@ -154,4 +160,16 @@ std::unique_ptr<raw_fd_ostream> lld::openLTOOutputFile(StringRef file) {
   if (!ec)
     return fs;
   return openFile(file);
+}
+
+std::error_code lld::dtltoNormalizePath(std::string &PathOut) {
+#if defined(_WIN32)
+  llvm::SmallString<128> Expanded;
+  if (auto EC = llvm::sys::windows::makeLong(PathOut, Expanded))
+    return EC;
+
+  PathOut.assign(Expanded.begin(), Expanded.end());
+#endif
+  (void)PathOut;
+  return std::error_code{};
 }

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -249,6 +249,10 @@ struct Config {
   llvm::SmallVector<llvm::StringRef, 0> searchPaths;
   llvm::SmallVector<llvm::StringRef, 0> symbolOrderingFile;
   llvm::SmallVector<llvm::StringRef, 0> thinLTOModulesToCompile;
+  llvm::StringRef dtltoDistributor;
+  llvm::SmallVector<llvm::StringRef, 0> dtltoDistributorArgs;
+  llvm::StringRef dtltoCompiler;
+  llvm::SmallVector<llvm::StringRef, 0> dtltoCompilerArgs;
   llvm::SmallVector<llvm::StringRef, 0> undefined;
   llvm::SmallVector<SymbolVersion, 0> dynamicList;
   llvm::SmallVector<uint8_t, 0> buildIdVector;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1341,6 +1341,11 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
       args.hasFlag(OPT_dependent_libraries, OPT_no_dependent_libraries, true);
   ctx.arg.disableVerify = args.hasArg(OPT_disable_verify);
   ctx.arg.discard = getDiscard(args);
+  ctx.arg.dtltoDistributor = args.getLastArgValue(OPT_thinlto_distributor_eq);
+  ctx.arg.dtltoDistributorArgs =
+      args::getStrings(args, OPT_thinlto_distributor_arg);
+  ctx.arg.dtltoCompiler = args.getLastArgValue(OPT_thinlto_compiler_eq);
+  ctx.arg.dtltoCompilerArgs = args::getStrings(args, OPT_thinlto_compiler_arg);
   ctx.arg.dwoDir = args.getLastArgValue(OPT_plugin_opt_dwo_dir_eq);
   ctx.arg.dynamicLinker = getDynamicLinker(ctx, args);
   ctx.arg.ehFrameHdr =

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/LTO/LTO.h"
+#include "llvm/Object/Archive.h"
 #include "llvm/Object/IRObjectFile.h"
 #include "llvm/Support/ARMAttributeParser.h"
 #include "llvm/Support/ARMBuildAttributes.h"
@@ -1739,6 +1740,33 @@ static uint8_t getOsAbi(const Triple &t) {
   }
 }
 
+// For DTLTO, bitcode member names must be valid paths to files on disk.
+// For thin archives, resolve `memberPath` relative to the archive's location.
+// Returns true if adjusted; false otherwise. Non-thin archives are unsupported.
+static bool dtltoAdjustMemberPathIfThinArchive(Ctx &ctx, StringRef archivePath,
+                                               std::string &memberPath) {
+  assert(!archivePath.empty() && !ctx.arg.dtltoDistributor.empty());
+
+  // Check if the archive file is a thin archive by reading its header.
+  auto bufferOrErr =
+      MemoryBuffer::getFileSlice(archivePath, sizeof(ThinArchiveMagic) - 1, 0);
+  if (std::error_code ec = bufferOrErr.getError()) {
+    ErrAlways(ctx) << "cannot open " << archivePath << ": " << ec.message();
+    return false;
+  }
+
+  if (!bufferOrErr->get()->getBuffer().starts_with(ThinArchiveMagic))
+    return false;
+
+  SmallString<64> resolvedPath;
+  if (path::is_relative(memberPath)) {
+    resolvedPath = path::parent_path(archivePath);
+    path::append(resolvedPath, memberPath);
+    memberPath = resolvedPath.str();
+  }
+  return true;
+}
+
 BitcodeFile::BitcodeFile(Ctx &ctx, MemoryBufferRef mb, StringRef archiveName,
                          uint64_t offsetInArchive, bool lazy)
     : InputFile(ctx, BitcodeKind, mb) {
@@ -1756,10 +1784,13 @@ BitcodeFile::BitcodeFile(Ctx &ctx, MemoryBufferRef mb, StringRef archiveName,
   // symbols later in the link stage). So we append file offset to make
   // filename unique.
   StringSaver &ss = ctx.saver;
-  StringRef name = archiveName.empty()
-                       ? ss.save(path)
-                       : ss.save(archiveName + "(" + path::filename(path) +
-                                 " at " + utostr(offsetInArchive) + ")");
+  StringRef name =
+      (archiveName.empty() ||
+       (!ctx.arg.dtltoDistributor.empty() &&
+        dtltoAdjustMemberPathIfThinArchive(ctx, archiveName, path)))
+          ? ss.save(path)
+          : ss.save(archiveName + "(" + path::filename(path) + " at " +
+                    utostr(offsetInArchive) + ")");
   MemoryBufferRef mbref(mb.getBuffer(), name);
 
   obj = CHECK2(lto::InputFile::create(mbref), this);

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1781,8 +1781,6 @@ BitcodeFile::BitcodeFile(Ctx &ctx, MemoryBufferRef mb, StringRef archiveName,
   if (ctx.arg.thinLTOIndexOnly)
     path = replaceThinLTOSuffix(ctx, mb.getBufferIdentifier());
 
-  // SCE_PRIVATE: begin DTLTO
-  // TODO: Investigate if we can remove this code.
   if (!ctx.arg.dtltoDistributor.empty())
     lld::dtltoNormalizePath(path);
 

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -17,6 +17,7 @@
 #include "SyntheticSections.h"
 #include "Target.h"
 #include "lld/Common/DWARF.h"
+#include "lld/Common/Filesystem.h"
 #include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/LTO/LTO.h"
@@ -1764,6 +1765,9 @@ static bool dtltoAdjustMemberPathIfThinArchive(Ctx &ctx, StringRef archivePath,
     path::append(resolvedPath, memberPath);
     memberPath = resolvedPath.str();
   }
+
+  lld::dtltoNormalizePath(memberPath);
+
   return true;
 }
 
@@ -1776,6 +1780,11 @@ BitcodeFile::BitcodeFile(Ctx &ctx, MemoryBufferRef mb, StringRef archiveName,
   std::string path = mb.getBufferIdentifier().str();
   if (ctx.arg.thinLTOIndexOnly)
     path = replaceThinLTOSuffix(ctx, mb.getBufferIdentifier());
+
+  // SCE_PRIVATE: begin DTLTO
+  // TODO: Investigate if we can remove this code.
+  if (!ctx.arg.dtltoDistributor.empty())
+    lld::dtltoNormalizePath(path);
 
   // ThinLTO assumes that all MemoryBufferRefs given to it have a unique
   // name. If two archives define two members with the same name, this

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -180,6 +180,13 @@ BitcodeCompiler::BitcodeCompiler(Ctx &ctx) : ctx(ctx) {
         std::string(ctx.arg.thinLTOPrefixReplaceNew),
         std::string(ctx.arg.thinLTOPrefixReplaceNativeObject),
         ctx.arg.thinLTOEmitImportsFiles, indexFile.get(), onIndexWrite);
+  } else if (!ctx.arg.dtltoDistributor.empty()) {
+    backend = lto::createOutOfProcessThinBackend(
+        llvm::hardware_concurrency(ctx.arg.thinLTOJobs), onIndexWrite,
+        ctx.arg.thinLTOEmitIndexFiles, ctx.arg.thinLTOEmitImportsFiles,
+        ctx.arg.outputFile, ctx.arg.dtltoDistributor,
+        ctx.arg.dtltoDistributorArgs, ctx.arg.dtltoCompiler,
+        ctx.arg.dtltoCompilerArgs, !ctx.arg.saveTempsArgs.empty());
   } else {
     backend = lto::createInProcessThinBackend(
         llvm::heavyweight_hardware_concurrency(ctx.arg.thinLTOJobs),

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -710,7 +710,17 @@ def thinlto_object_suffix_replace_eq: JJ<"thinlto-object-suffix-replace=">;
 def thinlto_prefix_replace_eq: JJ<"thinlto-prefix-replace=">;
 def thinlto_single_module_eq: JJ<"thinlto-single-module=">,
   HelpText<"Specify a single module to compile in ThinLTO mode, for debugging only">;
-
+def thinlto_distributor_eq: JJ<"thinlto-distributor=">,
+  HelpText<"Distributor to use for ThinLTO backend compilations. If specified, "
+  "ThinLTO backend compilations will be distributed.">;
+defm thinlto_distributor_arg: EEq<"thinlto-distributor-arg", "Arguments to "
+  "pass to the ThinLTO distributor">;
+def thinlto_compiler_eq: JJ<"thinlto-remote-compiler=">,
+  HelpText<"Compiler for the ThinLTO distributor to invoke for ThinLTO backend "
+  "compilations">;
+defm thinlto_compiler_arg: EEq<"thinlto-remote-compiler-arg", "Compiler "
+  "arguments for the ThinLTO distributor to pass for ThinLTO backend "
+  "compilations">;
 defm fat_lto_objects: BB<"fat-lto-objects",
     "Use the .llvm.lto section, which contains LLVM bitcode, in fat LTO object files to perform LTO.",
     "Ignore the .llvm.lto section in relocatable object files (default).">;

--- a/lld/docs/DTLTO.rst
+++ b/lld/docs/DTLTO.rst
@@ -1,0 +1,42 @@
+Integrated Distributed ThinLTO (DTLTO)
+======================================
+
+Integrated Distributed ThinLTO (DTLTO) enables the distribution of backend
+ThinLTO compilations via external distribution systems, such as Incredibuild,
+during the traditional link step.
+
+The implementation is documented here: https://llvm.org/docs/DTLTO.html.
+
+Currently, DTLTO is only supported in ELF LLD. Support will be added to other
+LLD flavours in the future.
+
+ELF LLD
+-------
+
+The command-line interface is as follows:
+
+- ``--thinlto-distributor=<path>``  
+  Specifies the file to execute as the distributor process. If specified,
+  ThinLTO backend compilations will be distributed.
+
+- ``--thinlto-remote-compiler=<path>``  
+  Specifies the path to the compiler that the distributor process will use for
+  backend compilations. The compiler invoked must match the version of LLD.
+
+- ``--thinlto-distributor-arg=<arg>``  
+  Specifies ``<arg>`` on the command line when invoking the distributor.
+  Can be specified multiple times.
+
+- ``--thinlto-remote-compiler-arg=<arg>``  
+  Appends ``<arg>`` to the remote compiler's command line.
+  Can be specified multiple times.
+
+  Options that introduce extra input/output files may cause miscompilation if
+  the distribution system does not automatically handle pushing/fetching them to
+  remote nodes. In such cases, configure the distributor - possibly using
+  ``--thinlto-distributor-arg=`` - to manage these dependencies. See the
+  distributor documentation for details.
+
+Some LLD LTO options (e.g., ``--lto-sample-profile=<file>``) are supported.
+Currently, other options are silently accepted but do not have the intended
+effect. Support for such options will be expanded in the future.

--- a/lld/docs/index.rst
+++ b/lld/docs/index.rst
@@ -147,3 +147,4 @@ document soon.
    ELF/start-stop-gc
    ELF/warn_backrefs
    MachO/index
+   DTLTO

--- a/lld/include/lld/Common/Filesystem.h
+++ b/lld/include/lld/Common/Filesystem.h
@@ -19,6 +19,7 @@ void unlinkAsync(StringRef path);
 std::error_code tryCreateFile(StringRef path);
 std::unique_ptr<llvm::raw_fd_ostream> openFile(StringRef file);
 std::unique_ptr<llvm::raw_fd_ostream> openLTOOutputFile(StringRef file);
+std::error_code dtltoNormalizePath(std::string &PathOut);
 } // namespace lld
 
 #endif

--- a/lld/test/ELF/dtlto/archive-thin.test
+++ b/lld/test/ELF/dtlto/archive-thin.test
@@ -1,0 +1,82 @@
+# REQUIRES: x86
+
+# Test that a DTLTO link succeeds and outputs the expected set of files
+# correctly when thin archives are present.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+# Generate ThinLTO bitcode files.
+RUN: opt -thinlto-bc t1.ll -o t1.bc -O2
+RUN: opt -thinlto-bc t2.ll -o t2.bc -O2
+RUN: opt -thinlto-bc t3.ll -o t3.bc -O2
+
+# Generate object files for mock.py to return.
+RUN: llc t1.ll --filetype=obj -o t1.o --relocation-model=pic
+RUN: llc t2.ll --filetype=obj -o t2.o --relocation-model=pic
+RUN: llc t3.ll --filetype=obj -o t3.o --relocation-model=pic
+
+RUN: llvm-ar rcs t1.a t1.bc --thin
+# Create this bitcode thin archive in a subdirectory to test the expansion of
+# the path to a bitcode file that is referenced using "..", e.g., in this case
+# "../t2.bc".
+RUN: mkdir lib
+RUN: llvm-ar rcs lib/t2.a t2.bc --thin
+# Create this bitcode thin archive with an absolute path entry containing "..".
+RUN: llvm-ar rcs t3.a %t/lib/../t3.bc --thin
+RUN: llvm-ar rcs t4.a t1.bc --thin
+
+RUN: mkdir %t/out && cd %t/out
+
+# Note that mock.py does not do any compilation, instead it simply writes the
+# contents of the object files supplied on the command line into the output
+# object files in job order.
+RUN: ld.lld --whole-archive %t/t1.a %t/lib/t2.a ../t3.a \
+RUN:   --no-whole-archive %t/t4.a \ 
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=../t1.o \
+RUN:   --thinlto-distributor-arg=../t2.o \
+RUN:   --thinlto-distributor-arg=../t3.o \
+RUN:   --save-temps
+
+RUN: ls | FileCheck %s --implicit-check-not=4
+
+# JSON jobs description.
+CHECK-DAG: a.{{[0-9]+}}.dist-file.json
+
+# Individual summary index files.
+CHECK-DAG: t1.{{[0-9]+}}.{{[0-9]+}}.native.o.thinlto.bc{{$}}
+CHECK-DAG: t2.{{[0-9]+}}.{{[0-9]+}}.native.o.thinlto.bc{{$}}
+CHECK-DAG: t3.{{[0-9]+}}.{{[0-9]+}}.native.o.thinlto.bc{{$}}
+
+# Native output object files.
+CHECK-DAG: t1.{{[0-9]+}}.{{[0-9]+}}.native.o{{$}}
+CHECK-DAG: t2.{{[0-9]+}}.{{[0-9]+}}.native.o{{$}}
+CHECK-DAG: t3.{{[0-9]+}}.{{[0-9]+}}.native.o{{$}}
+
+#--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}
+
+#--- t2.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t2() {
+entry:
+  ret void
+}
+
+#--- t3.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t3() {
+entry:
+  ret void
+}

--- a/lld/test/ELF/dtlto/empty.test
+++ b/lld/test/ELF/dtlto/empty.test
@@ -1,0 +1,44 @@
+# REQUIRES: x86
+
+# Test that DTLTO options are a no-op if no thinLTO is performed.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+RUN: opt t1.ll -o t1.o -O2
+RUN: opt t2.ll -o t2.o -O2
+
+# Common command-line arguments. Note that mock.py does not do any compilation;
+# instead, it simply writes the contents of the object files supplied on the
+# command line into the output object files in job order.
+RUN: echo "t1.o t2.o \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=no-exist1.o \
+RUN:   --thinlto-distributor-arg=no-exist2.o" > l.rsp
+
+# Check linking succeeds when all input files are Full LTO.
+RUN: ld.lld @l.rsp
+
+RUN: llc -filetype=obj t1.ll -o t1.o
+RUN: llc -filetype=obj t2.ll -o t2.o
+
+# Check linking succeeds when all input files are ET_RELs.
+RUN: ld.lld @l.rsp
+
+#--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}
+
+#--- t2.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t2() {
+entry:
+  ret void
+}

--- a/lld/test/ELF/dtlto/imports.test
+++ b/lld/test/ELF/dtlto/imports.test
@@ -1,0 +1,53 @@
+# REQUIRES: x86
+
+# Check that DTLTO creates imports lists if requested.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+RUN: opt -thinlto-bc t1.ll -o t1.bc -O2
+RUN: opt -thinlto-bc t2.ll -o t2.bc -O2
+
+# Generate object files for mock.py to return.
+RUN: llc t1.ll --filetype=obj -o t1.o --relocation-model=pic
+RUN: llc t2.ll --filetype=obj -o t2.o --relocation-model=pic
+
+# Common command-line arguments. Note that mock.py does not do any compilation;
+# instead, it simply writes the contents of the object files supplied on the
+# command line into the output object files in job order.
+RUN: echo "t1.bc t2.bc \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=t1.o \
+RUN:   --thinlto-distributor-arg=t2.o" > l.rsp
+
+# Check that imports files are not created normally.
+RUN: ld.lld @l.rsp
+RUN: ls | FileCheck %s --check-prefix=NOIMPORTSFILES
+NOIMPORTSFILES-NOT: .imports
+
+# Check that imports files are created with --thinlto-emit-imports-files.
+RUN: ld.lld @l.rsp --thinlto-emit-imports-files
+RUN: ls | FileCheck %s --check-prefix=IMPORTSFILES
+IMPORTSFILES: t1.bc.imports
+IMPORTSFILES: t2.bc.imports
+
+#--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}
+
+#--- t2.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @t1(...)
+
+define void @t2() {
+entry:
+  call void (...) @t1()
+  ret void
+}

--- a/lld/test/ELF/dtlto/index.test
+++ b/lld/test/ELF/dtlto/index.test
@@ -1,0 +1,44 @@
+# REQUIRES: x86
+
+# Check that DTLTO creates individual summary index files if requested.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+# Generate ThinLTO bitcode files.
+RUN: opt -thinlto-bc t1.ll -o t1.bc -O2
+RUN: opt -thinlto-bc t1.ll -o t2.bc -O2
+
+# Generate object files for mock.py to return.
+RUN: llc t1.ll --filetype=obj -o t1.o --relocation-model=pic
+
+# Use a response file for the common command-line arguments.
+# Note that mock.py does not perform any compilation; instead, it copies the
+# contents of the specified object files into the output object files, in the
+# order the jobs are received.
+# The "--start-lib/--end-lib" options are used to exercise the special case
+# where unused lazy object inputs result in empty index files.
+RUN: echo "t1.bc --start-lib t2.bc --end-lib \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=t1.o \
+RUN:   --thinlto-distributor-arg=t2.o" > l.rsp
+
+# Check that index files are not created normally.
+RUN: ld.lld @l.rsp
+RUN: ls | FileCheck %s --check-prefix=NOINDEXFILES
+NOINDEXFILES-NOT: .thinlto.bc
+
+# Check that index files are created with --thinlto-emit-index-files.
+RUN: ld.lld @l.rsp --thinlto-emit-index-files
+RUN: ls | FileCheck %s --check-prefix=INDEXFILES
+INDEXFILES: t1.bc.thinlto.bc
+INDEXFILES: t2.bc.thinlto.bc
+
+#--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}

--- a/lld/test/ELF/dtlto/options.test
+++ b/lld/test/ELF/dtlto/options.test
@@ -1,0 +1,41 @@
+# REQUIRES: x86
+
+# Test that DTLTO options are passed correctly to the distributor and
+# remote compiler.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+RUN: opt -thinlto-bc foo.ll -o foo.o
+
+# Note: validate.py does not perform any compilation. Instead, it validates the
+# received JSON, pretty-prints the JSON and the supplied arguments, and then
+# exits with an error. This allows FileCheck directives to verify the
+# distributor inputs.
+RUN: not ld.lld foo.o \
+RUN:   -o my.elf \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
+RUN:   --thinlto-distributor-arg=darg1=10 \
+RUN:   --thinlto-distributor-arg=darg2=20 \
+RUN:   --thinlto-remote-compiler=my_clang.exe \
+RUN:   --thinlto-remote-compiler-arg=carg1=20 \
+RUN:   --thinlto-remote-compiler-arg=carg2=30 2>&1 | FileCheck %s
+
+CHECK: distributor_args=['darg1=10', 'darg2=20']
+
+CHECK: "linker_output": "my.elf"
+
+CHECK: "my_clang.exe"
+CHECK: "carg1=20"
+CHECK: "carg2=30"
+
+CHECK: ld.lld: error: DTLTO backend compilation: cannot open native object file:
+
+#--- foo.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @foo() {
+entry:
+  ret void
+}

--- a/lld/test/ELF/dtlto/partitions.test
+++ b/lld/test/ELF/dtlto/partitions.test
@@ -1,0 +1,61 @@
+# REQUIRES: x86
+
+# Test that DTLTO works with more than one LTO partition.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+# Compile bitcode.
+RUN: llvm-as -o full.bc full.ll
+RUN: opt -thinlto-bc thin1.ll -o thin1.bc
+RUN: opt -thinlto-bc thin2.ll -o thin2.bc
+
+# Generate object files for mock.py to return.
+RUN: llc thin1.ll --filetype=obj -o thin1.o --relocation-model=pic
+RUN: llc thin2.ll --filetype=obj -o thin2.o --relocation-model=pic
+
+# Link with 3 LTO partitions.
+RUN: ld.lld full.bc thin1.bc thin2.bc \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=thin1.o \
+RUN:   --thinlto-distributor-arg=thin2.o \
+RUN:   --save-temps \
+RUN:   --lto-partitions=3
+
+# DTLTO temporary object files include the task number and a PID component. The
+# task number should incorporate the LTO partition number.
+RUN: ls | FileCheck %s
+CHECK: thin1.3.[[#]].native.o
+CHECK: thin2.4.[[#]].native.o
+
+#--- full.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @foo() {
+  call void @bar()
+  ret void
+}
+
+define void @bar() {
+  call void @foo()
+  ret void
+}
+
+#--- thin1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @baz() {
+entry:
+  ret void
+}
+
+#--- thin2.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @_start() {
+entry:
+  ret void
+}

--- a/lld/test/ELF/dtlto/save-temps.test
+++ b/lld/test/ELF/dtlto/save-temps.test
@@ -1,0 +1,39 @@
+# REQUIRES: x86
+
+# Check that DTLTO responds to --save-temps.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+# Generate ThinLTO bitcode files.
+RUN: opt -thinlto-bc t1.ll -o t1.bc -O2
+
+# Generate object files for mock.py to return.
+RUN: llc t1.ll --filetype=obj -o t1.o --relocation-model=pic
+
+# Use a response file for common command-line arguments.
+# Note that mock.py does not perform any compilation; instead, it simply writes
+# the contents of the object files supplied on the command line into the output
+# object files in job order.
+RUN: echo "t1.bc -o my.elf \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=t1.o" > l.rsp
+
+# Check that DTLTO temporary files are removed by default.
+RUN: ld.lld @l.rsp
+RUN: ls | FileCheck %s --check-prefix=REMOVED
+REMOVED-NOT: .json
+
+# Check that DTLTO temporary files are retained with --save-temps.
+RUN: ld.lld @l.rsp --save-temps
+RUN: ls | FileCheck %s --check-prefix=RETAINED
+RETAINED: my.[[#]].dist-file.json
+
+#--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}

--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -36,6 +36,7 @@ config.test_exec_root = os.path.join(config.lld_obj_root, "test")
 
 llvm_config.use_default_substitutions()
 llvm_config.use_lld()
+config.substitutions.append(("%llvm_src_root", config.llvm_src_root))
 
 tool_patterns = [
     "llc",

--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -249,11 +249,6 @@ LLVM_ABI std::error_code widenPath(const Twine &Path8,
 LLVM_ABI std::error_code makeLong(const Twine &Path8,
                                   llvm::SmallVectorImpl<char> &Result8);
 
-/// Retrieves the volume mount point from UTF-16 path as UTF-16 result.
-LLVM_ABI std::error_code
-getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path16,
-                      SmallVectorImpl<wchar_t> &Result16);
-
 } // end namespace windows
 } // end namespace sys
 } // end namespace llvm.

--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -247,11 +247,12 @@ LLVM_ABI std::error_code widenPath(const Twine &Path8,
 
 /// Convert UTF-8 path into a long form UTF-8 path.
 LLVM_ABI std::error_code makeLong(const Twine &Path8,
-                                  llvm::SmallVectorImpl<char> &Result);
+                                  llvm::SmallVectorImpl<char> &Result8);
 
 /// Retrieves the volume mount point from UTF-16 path as UTF-16 result.
-std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path,
-                                      SmallVectorImpl<wchar_t> &Result);
+LLVM_ABI std::error_code
+getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path16,
+                      SmallVectorImpl<wchar_t> &Result16);
 
 } // end namespace windows
 } // end namespace sys

--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -245,6 +245,14 @@ LLVM_ABI std::error_code widenPath(const Twine &Path8,
                                    SmallVectorImpl<wchar_t> &Path16,
                                    size_t MaxPathLen = MAX_PATH);
 
+/// Convert UTF-8 path into a long form UTF-8 path.
+LLVM_ABI std::error_code makeLong(const Twine &Path8,
+                                  llvm::SmallVectorImpl<char> &Result);
+
+/// Retrieves the volume mount point from UTF-16 path as UTF-16 result.
+std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path,
+                                      SmallVectorImpl<wchar_t> &Result);
+
 } // end namespace windows
 } // end namespace sys
 } // end namespace llvm.

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -58,6 +58,19 @@ static bool is_separator(const wchar_t value) {
   }
 }
 
+static void stripExtendedPrefix(wchar_t *&Data, DWORD &CountChars) {
+  if (CountChars >= 8 && ::memcmp(Data, L"\\\\?\\UNC\\", 16) == 0) {
+    // Convert \\?\UNC\foo\bar to \\foo\bar
+    CountChars -= 6;
+    Data += 6;
+    Data[0] = '\\';
+  } else if (CountChars >= 4 && ::memcmp(Data, L"\\\\?\\", 8) == 0) {
+    // Convert \\?\C:\foo to C:\foo
+    CountChars -= 4;
+    Data += 4;
+  }
+}
+
 namespace llvm {
 namespace sys {
 namespace windows {
@@ -123,6 +136,70 @@ std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
   }
 
   return UTF8ToUTF16(FullPath, Path16);
+}
+
+std::error_code makeLong(const Twine &Path8,
+                         llvm::SmallVectorImpl<char> &Result8) {
+  constexpr StringLiteral LongPathPrefix = R"(\\?\)";
+
+  SmallString<128> PathStorage;
+  StringRef PathStr = Path8.toStringRef(PathStorage);
+  bool HadPrefix = PathStr.starts_with(LongPathPrefix);
+
+  // Convert UTF-8 to UTF-16
+  SmallVector<wchar_t, 128> Path16;
+  if (std::error_code EC = widenPath(PathStr, Path16))
+    return EC;
+
+  // Start with a buffer equal to input.
+  llvm::SmallVector<wchar_t, 128> Long16;
+  DWORD Len = static_cast<DWORD>(Path16.size());
+
+  do {
+    Long16.resize_for_overwrite(Len); // grow
+
+    Len = ::GetLongPathNameW(Path16.data(), Long16.data(), Len);
+
+    // A zero return value indicates a failure other than insufficient space.
+    if (Len == 0)
+      return mapWindowsError(::GetLastError());
+
+    // If there's insufficient space, the len returned is larger than the len
+    // given - in this case len includes the null-terminator.
+  } while (Len >= Long16.size());
+
+  // On success, GetLongPathNameW returns the number of characters not
+  // including the null-terminator.
+  Long16.truncate(Len);
+  // Strip \\?\ or \\?\UNC\ prefix if it wasn't part of the original path
+  wchar_t *Data = Long16.data();
+  if (!HadPrefix)
+    stripExtendedPrefix(Data, Len);
+
+  return sys::windows::UTF16ToUTF8(Data, Len, Result8);
+}
+
+std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path,
+                                      SmallVectorImpl<wchar_t> &VolumeRoot) {
+  size_t Len = 128;
+  while (true) {
+    VolumeRoot.resize(Len);
+    BOOL Success =
+        ::GetVolumePathNameW(Path.data(), VolumeRoot.data(), VolumeRoot.size());
+    if (Success)
+      break;
+
+    DWORD Err = ::GetLastError();
+    if (Err != ERROR_INSUFFICIENT_BUFFER)
+      return mapWindowsError(Err);
+
+    Len *= 2;
+  }
+
+  // Ensure null-termination in edge case where buffer was exactly full
+  VolumeRoot.push_back(L'\0');
+  VolumeRoot.truncate(wcslen(VolumeRoot.data()));
+  return std::error_code();
 }
 
 } // end namespace windows
@@ -309,29 +386,10 @@ std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
 static std::error_code is_local_internal(SmallVectorImpl<wchar_t> &Path,
                                          bool &Result) {
   SmallVector<wchar_t, 128> VolumePath;
-  size_t Len = 128;
-  while (true) {
-    VolumePath.resize(Len);
-    BOOL Success =
-        ::GetVolumePathNameW(Path.data(), VolumePath.data(), VolumePath.size());
+  if (std::error_code EC = windows::getVolumeRootFromPath(Path, VolumePath))
+    return EC;
 
-    if (Success)
-      break;
-
-    DWORD Err = ::GetLastError();
-    if (Err != ERROR_INSUFFICIENT_BUFFER)
-      return mapWindowsError(Err);
-
-    Len *= 2;
-  }
-  // If the output buffer has exactly enough space for the path name, but not
-  // the null terminator, it will leave the output unterminated.  Push a null
-  // terminator onto the end to ensure that this never happens.
-  VolumePath.push_back(L'\0');
-  VolumePath.truncate(wcslen(VolumePath.data()));
-  const wchar_t *P = VolumePath.data();
-
-  UINT Type = ::GetDriveTypeW(P);
+  UINT Type = ::GetDriveTypeW(VolumePath.data());
   switch (Type) {
   case DRIVE_FIXED:
     Result = true;
@@ -392,16 +450,7 @@ static std::error_code realPathFromHandle(HANDLE H,
   // paths don't get canonicalized by file APIs.
   wchar_t *Data = Buffer.data();
   DWORD CountChars = Buffer.size();
-  if (CountChars >= 8 && ::memcmp(Data, L"\\\\?\\UNC\\", 16) == 0) {
-    // Convert \\?\UNC\foo\bar to \\foo\bar
-    CountChars -= 6;
-    Data += 6;
-    Data[0] = '\\';
-  } else if (CountChars >= 4 && ::memcmp(Data, L"\\\\?\\", 8) == 0) {
-    // Convert \\?\c:\foo to c:\foo
-    CountChars -= 4;
-    Data += 4;
-  }
+  stripExtendedPrefix(Data, CountChars);
 
   // Convert the result from UTF-16 to UTF-8.
   if (std::error_code EC = UTF16ToUTF8(Data, CountChars, RealPath))

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -178,29 +178,6 @@ std::error_code makeLong(const Twine &Path8,
   return sys::windows::UTF16ToUTF8(Data, Len, Result8);
 }
 
-std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path16,
-                                      SmallVectorImpl<wchar_t> &Result16) {
-  size_t Len = 128;
-  while (true) {
-    Result16.resize(Len);
-    BOOL Success =
-        ::GetVolumePathNameW(Path16.data(), Result16.data(), Result16.size());
-    if (Success)
-      break;
-
-    DWORD Err = ::GetLastError();
-    if (Err != ERROR_INSUFFICIENT_BUFFER)
-      return mapWindowsError(Err);
-
-    Len *= 2;
-  }
-
-  // Ensure null-termination in edge case where buffer was exactly full
-  Result16.push_back(L'\0');
-  Result16.truncate(wcslen(Result16.data()));
-  return std::error_code();
-}
-
 } // end namespace windows
 
 namespace fs {
@@ -385,10 +362,29 @@ std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
 static std::error_code is_local_internal(SmallVectorImpl<wchar_t> &Path,
                                          bool &Result) {
   SmallVector<wchar_t, 128> VolumePath;
-  if (std::error_code EC = windows::getVolumeRootFromPath(Path, VolumePath))
-    return EC;
+  size_t Len = 128;
+  while (true) {
+    VolumePath.resize(Len);
+    BOOL Success =
+        ::GetVolumePathNameW(Path.data(), VolumePath.data(), VolumePath.size());
 
-  UINT Type = ::GetDriveTypeW(VolumePath.data());
+    if (Success)
+      break;
+
+    DWORD Err = ::GetLastError();
+    if (Err != ERROR_INSUFFICIENT_BUFFER)
+      return mapWindowsError(Err);
+
+    Len *= 2;
+  }
+  // If the output buffer has exactly enough space for the path name, but not
+  // the null terminator, it will leave the output unterminated.  Push a null
+  // terminator onto the end to ensure that this never happens.
+  VolumePath.push_back(L'\0');
+  VolumePath.truncate(wcslen(VolumePath.data()));
+  const wchar_t *P = VolumePath.data();
+
+  UINT Type = ::GetDriveTypeW(P);
   switch (Type) {
   case DRIVE_FIXED:
     Result = true;

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -156,7 +156,7 @@ std::error_code makeLong(const Twine &Path8,
   DWORD Len = static_cast<DWORD>(Path16.size());
 
   do {
-    Long16.resize_for_overwrite(Len); // grow
+    Long16.resize_for_overwrite(Len);
 
     Len = ::GetLongPathNameW(Path16.data(), Long16.data(), Len);
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -146,7 +146,6 @@ std::error_code makeLong(const Twine &Path8,
   StringRef PathStr = Path8.toStringRef(PathStorage);
   bool HadPrefix = PathStr.starts_with(LongPathPrefix);
 
-  // Convert UTF-8 to UTF-16
   SmallVector<wchar_t, 128> Path16;
   if (std::error_code EC = widenPath(PathStr, Path16))
     return EC;
@@ -179,13 +178,13 @@ std::error_code makeLong(const Twine &Path8,
   return sys::windows::UTF16ToUTF8(Data, Len, Result8);
 }
 
-std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path,
-                                      SmallVectorImpl<wchar_t> &VolumeRoot) {
+std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path16,
+                                      SmallVectorImpl<wchar_t> &Result16) {
   size_t Len = 128;
   while (true) {
-    VolumeRoot.resize(Len);
+    Result16.resize(Len);
     BOOL Success =
-        ::GetVolumePathNameW(Path.data(), VolumeRoot.data(), VolumeRoot.size());
+        ::GetVolumePathNameW(Path16.data(), Result16.data(), Result16.size());
     if (Success)
       break;
 
@@ -197,8 +196,8 @@ std::error_code getVolumeRootFromPath(SmallVectorImpl<wchar_t> &Path,
   }
 
   // Ensure null-termination in edge case where buffer was exactly full
-  VolumeRoot.push_back(L'\0');
-  VolumeRoot.truncate(wcslen(VolumeRoot.data()));
+  Result16.push_back(L'\0');
+  Result16.truncate(wcslen(Result16.data()));
   return std::error_code();
 }
 

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2528,21 +2528,6 @@ static std::string stripPrefix(llvm::StringRef P) {
   return P.str();
 }
 
-void swapDriveLetterWithUNC(llvm::SmallString<MAX_PATH * 2> &Max) {
-  if (Max.size() >= 2 && llvm::isAlpha(Max[0]) && Max[1] == ':') {
-    llvm::SmallString<16> UNC;
-    UNC.append("\\\\localhost\\");
-    UNC += Max[0]; // drive letter
-    UNC += '$';
-
-    // Remove the first two characters (e.g., "C:")
-    Max.erase(Max.begin(), Max.begin() + 2);
-
-    // Prepend UNC
-    Max.insert(Max.begin(), UNC.begin(), UNC.end());
-  }
-}
-
 TEST_F(FileSystemTest, makeLong) {
   if (!isShortNameEnabledForPath(TestDirectory.str()))
     GTEST_SKIP() << "Short names not enabled on volume.";
@@ -2561,10 +2546,6 @@ TEST_F(FileSystemTest, makeLong) {
   for (size_t I = 0; I < NLevels; ++I)
     Max.append(OneDir);
 
-  swapDriveLetterWithUNC(Max);
-
-  std::cout << "Max: " << Max.str().str() << "\n";
-
   ASSERT_NO_ERROR(fs::create_directories(Max));
   std::string MaxShortWithPrefix = getShortPathName(Max);
   ASSERT_TRUE(StringRef(MaxShortWithPrefix).starts_with(R"(\\?\)"))
@@ -2572,14 +2553,14 @@ TEST_F(FileSystemTest, makeLong) {
 
   std::string MaxShort = stripPrefix(MaxShortWithPrefix);
 
-  // Case 1: Non-existent short path.
+  // === Case 1: Non-existent short path ===
   SmallString<128> NoExist("NotEre~1");
   ASSERT_FALSE(fs::exists(NoExist));
   SmallString<128> NoExistResult;
   EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
   EXPECT_TRUE(NoExistResult.empty());
 
-  // Case 2: Short path that exists.
+  // === Case 2: Short path that exists ===
   SmallString<128> ShortResult;
   ASSERT_FALSE(windows::makeLong(Short, ShortResult));
   fs::UniqueID ShortID1, ShortID2;
@@ -2587,7 +2568,7 @@ TEST_F(FileSystemTest, makeLong) {
   ASSERT_NO_ERROR(fs::getUniqueID(ShortResult, ShortID2));
   EXPECT_EQ(ShortID1, ShortID2);
 
-  // Case 3: Short path greater than MAX_PATH, no prefix.
+  // === Case 3: Short path greater than MAX_PATH, no prefix ===
   SmallString<128> MaxResult;
   ASSERT_FALSE(windows::makeLong(MaxShort, MaxResult));
   fs::UniqueID MaxID1, MaxID2;
@@ -2597,10 +2578,7 @@ TEST_F(FileSystemTest, makeLong) {
   EXPECT_FALSE(StringRef(MaxResult).starts_with(R"(\\?\)"))
       << "Expected unprefixed result, got: " << MaxResult;
 
-      
-  std::cout << "MaxResult: " << MaxResult.str().str() << "\n";
-
-  // Case 4: Short path greater than MAX_PATH, with prefix.
+  // === Case 4: Short path greater than MAX_PATH, with prefix ===
   SmallString<128> MaxPrefixedResult;
   ASSERT_FALSE(windows::makeLong(MaxShortWithPrefix, MaxPrefixedResult));
   fs::UniqueID MaxPrefixedID1, MaxPrefixedID2;
@@ -2609,9 +2587,6 @@ TEST_F(FileSystemTest, makeLong) {
   EXPECT_EQ(MaxPrefixedID1, MaxPrefixedID2);
   EXPECT_TRUE(StringRef(MaxPrefixedResult).starts_with(R"(\\?\)"))
       << "Expected prefixed result, got: " << MaxPrefixedResult;
-
-  
-      std::cout << "MaxPrefixedResult: " << MaxPrefixedResult.str().str() << "\n";
 
   // Cleanup
   ASSERT_NO_ERROR(fs::remove_directories(TestDirectory.str()));

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2489,7 +2489,7 @@ static bool isShortNameEnabledForPath(llvm::StringRef Path8) {
 
 /// Returns the 8.3 path for the given UTF-8 path, or an empty string
 /// on failure. Uses Win32 GetShortPathNameW.
-static std::string getShortPathUtf8(llvm::StringRef Path8) {
+static std::string getShortPathName(llvm::StringRef Path8) {
   using namespace llvm;
 
   // Convert UTF-8 to UTF-16
@@ -2533,8 +2533,8 @@ TEST_F(FileSystemTest, makeLong) {
     GTEST_SKIP() << "Short names not enabled on volume.";
 
   // Get a short-path version of the test directory
-  std::string Short8 = getShortPathUtf8(TestDirectory);
-  ASSERT_FALSE(Short8.empty())
+  std::string Short = getShortPathName(TestDirectory);
+  ASSERT_FALSE(Short.empty())
       << "Expected short path form for test directory.";
 
   // Setup: Create a path where even if all components were reduced to short
@@ -2542,53 +2542,53 @@ TEST_F(FileSystemTest, makeLong) {
   //        exceed MAX_PATH.
   constexpr const char *OneDir = "\\123456789"; // >8 chars
   const size_t NLevels = (MAX_PATH / 8) + 1;
-  SmallString<MAX_PATH * 2> Long(TestDirectory);
+  SmallString<MAX_PATH * 2> Max(TestDirectory);
   for (size_t I = 0; I < NLevels; ++I)
-    Long.append(OneDir);
+    Max.append(OneDir);
 
-  ASSERT_NO_ERROR(fs::create_directories(Long));
-  std::string LongShort8WithPrefix = getShortPathUtf8(Long);
-  ASSERT_TRUE(StringRef(LongShort8WithPrefix).starts_with(R"(\\?\)"))
-      << "Expected prefixed short path, got: " << LongShort8WithPrefix;
+  ASSERT_NO_ERROR(fs::create_directories(Max));
+  std::string MaxShortWithPrefix = getShortPathName(Max);
+  ASSERT_TRUE(StringRef(MaxShortWithPrefix).starts_with(R"(\\?\)"))
+      << "Expected prefixed short path, got: " << MaxShortWithPrefix;
 
-  std::string LongShort8 = stripPrefix(LongShort8WithPrefix);
+  std::string MaxShort = stripPrefix(MaxShortWithPrefix);
 
-  // === Case 1: Non-existent short path should fail ===
-  SmallString<128> NoExist("No Existy~1 Path");
+  // === Case 1: Non-existent short path ===
+  SmallString<128> NoExist("NotEre~1");
   SmallString<128> NoExistResult;
   EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
   EXPECT_TRUE(NoExistResult.empty());
 
-  // === Case 2: Short path that exists, no prefix ===
+  // === Case 2: Short path that exists ===
   SmallString<128> ShortResult;
-  ASSERT_FALSE(windows::makeLong(Short8, ShortResult));
+  ASSERT_FALSE(windows::makeLong(Short, ShortResult));
   fs::UniqueID ShortID1, ShortID2;
-  ASSERT_NO_ERROR(fs::getUniqueID(Short8, ShortID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(Short, ShortID1));
   ASSERT_NO_ERROR(fs::getUniqueID(ShortResult, ShortID2));
   EXPECT_EQ(ShortID1, ShortID2);
 
-  // === Case 3: Long short path (no prefix) ===
-  SmallString<128> LongResult;
-  ASSERT_FALSE(windows::makeLong(LongShort8, LongResult));
-  fs::UniqueID LongID1, LongID2;
-  ASSERT_NO_ERROR(fs::getUniqueID(LongShort8, LongID1));
-  ASSERT_NO_ERROR(fs::getUniqueID(LongResult, LongID2));
-  EXPECT_EQ(LongID1, LongID2);
-  EXPECT_FALSE(StringRef(LongResult).starts_with(R"(\\?\)"))
-      << "Expected unprefixed result, got: " << LongResult;
+  // === Case 3: Short path greater than MAX_PATH, no prefix ===
+  SmallString<128> MaxResult;
+  ASSERT_FALSE(windows::makeLong(MaxShort, MaxResult));
+  fs::UniqueID MaxID1, MaxID2;
+  ASSERT_NO_ERROR(fs::getUniqueID(MaxShort, MaxID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(MaxResult, MaxID2));
+  EXPECT_EQ(MaxID1, MaxID2);
+  EXPECT_FALSE(StringRef(MaxResult).starts_with(R"(\\?\)"))
+      << "Expected unprefixed result, got: " << MaxResult;
 
-  // === Case 4: Long short path with prefix ===
-  SmallString<128> LongPrefixedResult;
-  ASSERT_FALSE(windows::makeLong(LongShort8WithPrefix, LongPrefixedResult));
-  fs::UniqueID LongPrefixedID1, LongPrefixedID2;
-  ASSERT_NO_ERROR(fs::getUniqueID(LongShort8WithPrefix, LongPrefixedID1));
-  ASSERT_NO_ERROR(fs::getUniqueID(LongPrefixedResult, LongPrefixedID2));
-  EXPECT_EQ(LongPrefixedID1, LongPrefixedID2);
-  EXPECT_TRUE(StringRef(LongPrefixedResult).starts_with(R"(\\?\)"))
-      << "Expected prefixed result, got: " << LongPrefixedResult;
+  // === Case 4: Short path greater than MAX_PATH, with prefix ===
+  SmallString<128> MaxPrefixedResult;
+  ASSERT_FALSE(windows::makeLong(MaxShortWithPrefix, MaxPrefixedResult));
+  fs::UniqueID MaxPrefixedID1, MaxPrefixedID2;
+  ASSERT_NO_ERROR(fs::getUniqueID(MaxShortWithPrefix, MaxPrefixedID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(MaxPrefixedResult, MaxPrefixedID2));
+  EXPECT_EQ(MaxPrefixedID1, MaxPrefixedID2);
+  EXPECT_TRUE(StringRef(MaxPrefixedResult).starts_with(R"(\\?\)"))
+      << "Expected prefixed result, got: " << MaxPrefixedResult;
 
   // Cleanup
-  ASSERT_NO_ERROR(fs::remove(Long));
+  ASSERT_NO_ERROR(fs::remove(Max));
 }
 
 // Windows refuses lock request if file region is already locked by the same

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2565,7 +2565,7 @@ static std::string getShortPathUtf8(llvm::StringRef Path8) {
 
 static std::string stripPrefix(llvm::StringRef P) {
   if (P.starts_with(R"(\\?\UNC\)"))
-    return "\\" + P.drop_front(8).str();
+    return R"\\" + P.drop_front(8).str(); // or "\\" + P.drop_front(7).str();
   if (P.starts_with(R"(\\?\)"))
     return P.drop_front(4).str();
   return P.str();

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2450,54 +2450,35 @@ TEST_F(FileSystemTest, widenPath) {
 
 #ifdef _WIN32
 
-/// Checks whether short (8.3) names are enabled for the volume containing the
-/// given UTF-8 path.
-static bool isShortNameEnabledForPath(llvm::StringRef Path8) {
-
-  llvm::SmallVector<wchar_t, 128> VolumeRoot16;
-  if (windows::widenPath(path::root_path(Path8), VolumeRoot16))
+/// Checks whether short (8.3) names are enabled in the given UTF-8 path. This
+/// is the best way I have found of checking this. Note that 8.3 names can be
+/// enabled and disabled on a per-folder, per-volume, and per-system basis.
+static bool areShortNamesEnabled(llvm::StringRef Path8) {
+  // Create a directory under Path8 with a name long enough that Windows will
+  // provide a shortened 8.3 form name, if 8.3 names are enabled.
+  SmallString<256> Dir(Path8);
+  path::append(Dir, "verylongdir");
+  if (std::error_code EC = fs::create_directories(Dir))
     return false;
 
-  // Attempt to load AreShortNamesEnabled dynamically (it's avalible only on
-  // some versions of Windows).
-  using AreShortNamesEnabledFn = BOOL(WINAPI *)(HANDLE, BOOL *);
-  auto Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
-  if (!Kernel32)
-    return false;
+  // Check if the expected 8.3 form name was created.
+  SmallString<256> Short(Path8);
+  path::append(Short, "verylo~1");
+  bool Result = fs::is_directory(Short);
 
-  auto *FnPtr =
-      reinterpret_cast<AreShortNamesEnabledFn>(reinterpret_cast<void *>(
-          ::GetProcAddress(Kernel32, "AreShortNamesEnabled")));
-  if (!FnPtr)
-    return false;
-
-  // Open the volume root for querying.
-  HANDLE VolumeHandle = ::CreateFileW(
-      VolumeRoot16.data(), GENERIC_READ,
-      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
-      OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
-
-  if (VolumeHandle == INVALID_HANDLE_VALUE)
-    return false;
-
-  BOOL Enabled = FALSE;
-  bool Success = FnPtr(static_cast<void *>(VolumeHandle), &Enabled);
-  ::CloseHandle(VolumeHandle);
-
-  return Success && Enabled;
+  fs::remove_directories(Dir);
+  return Result;
 }
 
-/// Returns the 8.3 path for the given UTF-8 path, or an empty string
-/// on failure. Uses Win32 GetShortPathNameW.
+/// Returns the 8.3 path for the given UTF-8 path, or an empty string on
+/// failure. Uses Win32 GetShortPathNameW.
 static std::string getShortPathName(llvm::StringRef Path8) {
-  using namespace llvm;
-
-  // Convert UTF-8 to UTF-16
+  // Convert UTF-8 to UTF-16.
   SmallVector<wchar_t, MAX_PATH> Path16;
   if (std::error_code EC = sys::windows::widenPath(Path8, Path16))
     return {};
 
-  // Get required buffer size for short path (includes null terminator)
+  // Get required buffer size for short path (includes null terminator).
   DWORD Required = ::GetShortPathNameW(Path16.data(), nullptr, 0);
   if (Required == 0)
     return {};
@@ -2520,6 +2501,8 @@ static std::string getShortPathName(llvm::StringRef Path8) {
   return std::string(Utf8Result);
 }
 
+/// Removes the Windows extended path prefix (\\?\ or \\?\UNC\) from the given
+/// UTF-8 path, if present.
 static std::string stripPrefix(llvm::StringRef P) {
   if (P.starts_with(R"(\\?\UNC\)"))
     return "\\" + P.drop_front(7).str();
@@ -2528,7 +2511,9 @@ static std::string stripPrefix(llvm::StringRef P) {
   return P.str();
 }
 
-static void verifyPathEquality(std::string& S1, SmallString<128>& S2) {
+/// Verifies that the two paths refer to the same file or directory by comparing
+/// their UniqueIDs.
+static void verifyPathEquality(std::string &S1, SmallString<128> &S2) {
   fs::UniqueID ID1, ID2;
   ASSERT_NO_ERROR(fs::getUniqueID(S1, ID1));
   ASSERT_NO_ERROR(fs::getUniqueID(S2, ID2));
@@ -2536,29 +2521,35 @@ static void verifyPathEquality(std::string& S1, SmallString<128>& S2) {
 }
 
 TEST_F(FileSystemTest, makeLong) {
-  if (!isShortNameEnabledForPath(TestDirectory.str()))
-    GTEST_SKIP() << "Short names not enabled on volume.";
+  if (!areShortNamesEnabled(TestDirectory.str()))
+    GTEST_SKIP() << "Short names not enabled in: " << TestDirectory;
 
-  // Get a short-path version of the test directory
-  std::string Short = getShortPathName(TestDirectory);
-  ASSERT_FALSE(Short.empty())
-      << "Expected short path form for test directory.";
+  // Setup: A test directory longer than 8 characters for which a distinct
+  // short form will be created on Windows. Typically, 123456~1.
+  constexpr const char *OneDir = "\\123456789"; // >8 chars
 
   // Setup: Create a path where even if all components were reduced to short
-  //        form (typically 8 characters e.g. 123456~1) the total length would
-  //        exceed MAX_PATH.
-  constexpr const char *OneDir = "\\123456789"; // >8 chars
+  // form, the total length would exceed MAX_PATH.
+  SmallString<MAX_PATH * 2> Deep(TestDirectory);
   const size_t NLevels = (MAX_PATH / 8) + 1;
-  SmallString<MAX_PATH * 2> Max(TestDirectory);
   for (size_t I = 0; I < NLevels; ++I)
-    Max.append(OneDir);
+    Deep.append(OneDir);
 
-  ASSERT_NO_ERROR(fs::create_directories(Max));
-  std::string MaxShortWithPrefix = getShortPathName(Max);
-  ASSERT_TRUE(StringRef(MaxShortWithPrefix).starts_with(R"(\\?\)"))
-      << "Expected prefixed short path, got: " << MaxShortWithPrefix;
+  ASSERT_NO_ERROR(fs::create_directories(Deep));
 
-  std::string MaxShort = stripPrefix(MaxShortWithPrefix);
+  // Setup: Create prefixed and non-prefixed 8.3 forms of the deep test path we
+  // just created.
+  std::string DeepShortWithPrefix = getShortPathName(Deep);
+  ASSERT_TRUE(StringRef(DeepShortWithPrefix).starts_with(R"(\\?\)"))
+      << "Expected prefixed short path, got: " << DeepShortWithPrefix;
+  std::string DeepShort = stripPrefix(DeepShortWithPrefix);
+
+  // Setup: Create an 8.3-form short path for the first-level directory.
+  SmallString<256> FirstLevel(TestDirectory);
+  FirstLevel.append(OneDir);
+  std::string Short = getShortPathName(FirstLevel);
+  ASSERT_FALSE(Short.empty())
+      << "Expected 8.3 short path form for test directory.";
 
   // Case 1: Non-existent short path.
   SmallString<128> NoExist("NotEre~1");
@@ -2567,26 +2558,26 @@ TEST_F(FileSystemTest, makeLong) {
   EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
   EXPECT_TRUE(NoExistResult.empty());
 
-  // Case 2: Short path that exists.
+  // Case 2: Valid short path.
   SmallString<128> ShortResult;
   ASSERT_FALSE(windows::makeLong(Short, ShortResult));
   verifyPathEquality(Short, ShortResult);
 
-  // Case 3: Short path greater than MAX_PATH, no prefix.
-  SmallString<128> MaxResult;
-  ASSERT_FALSE(windows::makeLong(MaxShort, MaxResult));
-  verifyPathEquality(MaxShort, MaxResult);
-  EXPECT_FALSE(StringRef(MaxResult).starts_with(R"(\\?\)"))
-      << "Expected unprefixed result, got: " << MaxResult;
+  // Case 3: Deep short path without \\?\ prefix.
+  SmallString<128> DeepResult;
+  ASSERT_FALSE(windows::makeLong(DeepShort, DeepResult));
+  verifyPathEquality(DeepShort, DeepResult);
+  EXPECT_FALSE(StringRef(DeepResult).starts_with(R"(\\?\)"))
+      << "Expected unprefixed result, got: " << DeepResult;
 
-  // Case 4: Short path greater than MAX_PATH, with prefix.
-  SmallString<128> MaxPrefixedResult;
-  ASSERT_FALSE(windows::makeLong(MaxShortWithPrefix, MaxPrefixedResult));
-  verifyPathEquality(MaxShortWithPrefix, MaxPrefixedResult);
-  EXPECT_TRUE(StringRef(MaxPrefixedResult).starts_with(R"(\\?\)"))
-      << "Expected prefixed result, got: " << MaxPrefixedResult;
+  // Case 4: Deep short path with \\?\ prefix.
+  SmallString<128> DeepPrefixedResult;
+  ASSERT_FALSE(windows::makeLong(DeepShortWithPrefix, DeepPrefixedResult));
+  verifyPathEquality(DeepShortWithPrefix, DeepPrefixedResult);
+  EXPECT_TRUE(StringRef(DeepPrefixedResult).starts_with(R"(\\?\)"))
+      << "Expected prefixed result, got: " << DeepPrefixedResult;
 
-  // Cleanup
+  // Cleanup.
   ASSERT_NO_ERROR(fs::remove_directories(TestDirectory.str()));
 }
 

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2528,6 +2528,13 @@ static std::string stripPrefix(llvm::StringRef P) {
   return P.str();
 }
 
+static void verifyPathEquality(std::string& S1, SmallString<128>& S2) {
+  fs::UniqueID ID1, ID2;
+  ASSERT_NO_ERROR(fs::getUniqueID(S1, ID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(S2, ID2));
+  EXPECT_EQ(ID1, ID2);
+}
+
 TEST_F(FileSystemTest, makeLong) {
   if (!isShortNameEnabledForPath(TestDirectory.str()))
     GTEST_SKIP() << "Short names not enabled on volume.";
@@ -2553,38 +2560,29 @@ TEST_F(FileSystemTest, makeLong) {
 
   std::string MaxShort = stripPrefix(MaxShortWithPrefix);
 
-  // === Case 1: Non-existent short path ===
+  // Case 1: Non-existent short path.
   SmallString<128> NoExist("NotEre~1");
   ASSERT_FALSE(fs::exists(NoExist));
   SmallString<128> NoExistResult;
   EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
   EXPECT_TRUE(NoExistResult.empty());
 
-  // === Case 2: Short path that exists ===
+  // Case 2: Short path that exists.
   SmallString<128> ShortResult;
   ASSERT_FALSE(windows::makeLong(Short, ShortResult));
-  fs::UniqueID ShortID1, ShortID2;
-  ASSERT_NO_ERROR(fs::getUniqueID(Short, ShortID1));
-  ASSERT_NO_ERROR(fs::getUniqueID(ShortResult, ShortID2));
-  EXPECT_EQ(ShortID1, ShortID2);
+  verifyPathEquality(Short, ShortResult);
 
-  // === Case 3: Short path greater than MAX_PATH, no prefix ===
+  // Case 3: Short path greater than MAX_PATH, no prefix.
   SmallString<128> MaxResult;
   ASSERT_FALSE(windows::makeLong(MaxShort, MaxResult));
-  fs::UniqueID MaxID1, MaxID2;
-  ASSERT_NO_ERROR(fs::getUniqueID(MaxShort, MaxID1));
-  ASSERT_NO_ERROR(fs::getUniqueID(MaxResult, MaxID2));
-  EXPECT_EQ(MaxID1, MaxID2);
+  verifyPathEquality(MaxShort, MaxResult);
   EXPECT_FALSE(StringRef(MaxResult).starts_with(R"(\\?\)"))
       << "Expected unprefixed result, got: " << MaxResult;
 
-  // === Case 4: Short path greater than MAX_PATH, with prefix ===
+  // Case 4: Short path greater than MAX_PATH, with prefix.
   SmallString<128> MaxPrefixedResult;
   ASSERT_FALSE(windows::makeLong(MaxShortWithPrefix, MaxPrefixedResult));
-  fs::UniqueID MaxPrefixedID1, MaxPrefixedID2;
-  ASSERT_NO_ERROR(fs::getUniqueID(MaxShortWithPrefix, MaxPrefixedID1));
-  ASSERT_NO_ERROR(fs::getUniqueID(MaxPrefixedResult, MaxPrefixedID2));
-  EXPECT_EQ(MaxPrefixedID1, MaxPrefixedID2);
+  verifyPathEquality(MaxShortWithPrefix, MaxPrefixedResult);
   EXPECT_TRUE(StringRef(MaxPrefixedResult).starts_with(R"(\\?\)"))
       << "Expected prefixed result, got: " << MaxPrefixedResult;
 

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2450,55 +2450,12 @@ TEST_F(FileSystemTest, widenPath) {
 
 #ifdef _WIN32
 
-TEST_F(FileSystemTest, getVolumeRootFromPath) {
-  SmallVector<wchar_t, 128> Path16;
-
-  ASSERT_FALSE(sys::windows::UTF8ToUTF16(TestDirectory, Path16));
-
-  SmallVector<wchar_t, 128> VolumeRoot16;
-  ASSERT_FALSE(sys::windows::getVolumeRootFromPath(Path16, VolumeRoot16));
-
-  SmallString<128> VolumeRoot8;
-  ASSERT_FALSE(sys::windows::UTF16ToUTF8(VolumeRoot16.data(),
-                                         VolumeRoot16.size(), VolumeRoot8));
-
-  SmallString<128> ExpectedRoot(sys::path::root_name(TestDirectory));
-  ExpectedRoot += "\\";
-
-  EXPECT_EQ(VolumeRoot8, ExpectedRoot);
-}
-
-/// Resolves a UTF-16 path to its absolute form using GetFullPathNameW.
-/// Returns true on success and stores the result in `Result`.
-static bool getFullPath(llvm::SmallVectorImpl<wchar_t> &Path16,
-                        llvm::SmallVectorImpl<wchar_t> &Result) {
-  // Call GetFullPathNameW to get the required buffer size.
-  DWORD Len = ::GetFullPathNameW(Path16.data(), 0, nullptr, nullptr);
-  if (Len == 0)
-    return false;
-
-  // Call GetFullPathNameW to get the required buffer size.
-  Result.resize(Len);
-  DWORD FinalLen =
-      ::GetFullPathNameW(Path16.data(), Len, Result.data(), nullptr);
-  return FinalLen > 0 && FinalLen < Len;
-}
-
 /// Checks whether short (8.3) names are enabled for the volume containing the
 /// given UTF-8 path.
 static bool isShortNameEnabledForPath(llvm::StringRef Path8) {
-  llvm::SmallVector<wchar_t, 128> Path16;
-  if (windows::widenPath(Path8, Path16))
-    return false;
 
-  SmallVector<wchar_t, 128> FullPath16;
-  if (!getFullPath(Path16, FullPath16))
-    return false;
-
-  // Get volume root.
   llvm::SmallVector<wchar_t, 128> VolumeRoot16;
-  if (std::error_code EC =
-          windows::getVolumeRootFromPath(FullPath16, VolumeRoot16))
+  if (windows::widenPath(path::root_path(Path8), VolumeRoot16))
     return false;
 
   // Attempt to load AreShortNamesEnabled dynamically (it's avalible only on
@@ -2565,7 +2522,7 @@ static std::string getShortPathUtf8(llvm::StringRef Path8) {
 
 static std::string stripPrefix(llvm::StringRef P) {
   if (P.starts_with(R"(\\?\UNC\)"))
-    return R"\\" + P.drop_front(8).str(); // or "\\" + P.drop_front(7).str();
+    return "\\" + P.drop_front(7).str();
   if (P.starts_with(R"(\\?\)"))
     return P.drop_front(4).str();
   return P.str();

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2555,6 +2555,7 @@ TEST_F(FileSystemTest, makeLong) {
 
   // === Case 1: Non-existent short path ===
   SmallString<128> NoExist("NotEre~1");
+  ASSERT_FALSE(fs::exists(NoExist));
   SmallString<128> NoExistResult;
   EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
   EXPECT_TRUE(NoExistResult.empty());
@@ -2588,7 +2589,7 @@ TEST_F(FileSystemTest, makeLong) {
       << "Expected prefixed result, got: " << MaxPrefixedResult;
 
   // Cleanup
-  ASSERT_NO_ERROR(fs::remove(Max));
+  ASSERT_NO_ERROR(fs::remove_directories(TestDirectory.str()));
 }
 
 // Windows refuses lock request if file region is already locked by the same

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2528,6 +2528,21 @@ static std::string stripPrefix(llvm::StringRef P) {
   return P.str();
 }
 
+void swapDriveLetterWithUNC(llvm::SmallString<MAX_PATH * 2> &Max) {
+  if (Max.size() >= 2 && llvm::isAlpha(Max[0]) && Max[1] == ':') {
+    llvm::SmallString<16> UNC;
+    UNC.append("\\\\localhost\\");
+    UNC += Max[0]; // drive letter
+    UNC += '$';
+
+    // Remove the first two characters (e.g., "C:")
+    Max.erase(Max.begin(), Max.begin() + 2);
+
+    // Prepend UNC
+    Max.insert(Max.begin(), UNC.begin(), UNC.end());
+  }
+}
+
 TEST_F(FileSystemTest, makeLong) {
   if (!isShortNameEnabledForPath(TestDirectory.str()))
     GTEST_SKIP() << "Short names not enabled on volume.";
@@ -2546,6 +2561,10 @@ TEST_F(FileSystemTest, makeLong) {
   for (size_t I = 0; I < NLevels; ++I)
     Max.append(OneDir);
 
+  swapDriveLetterWithUNC(Max);
+
+  std::cout << "Max: " << Max.str().str() << "\n";
+
   ASSERT_NO_ERROR(fs::create_directories(Max));
   std::string MaxShortWithPrefix = getShortPathName(Max);
   ASSERT_TRUE(StringRef(MaxShortWithPrefix).starts_with(R"(\\?\)"))
@@ -2553,14 +2572,14 @@ TEST_F(FileSystemTest, makeLong) {
 
   std::string MaxShort = stripPrefix(MaxShortWithPrefix);
 
-  // === Case 1: Non-existent short path ===
+  // Case 1: Non-existent short path.
   SmallString<128> NoExist("NotEre~1");
   ASSERT_FALSE(fs::exists(NoExist));
   SmallString<128> NoExistResult;
   EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
   EXPECT_TRUE(NoExistResult.empty());
 
-  // === Case 2: Short path that exists ===
+  // Case 2: Short path that exists.
   SmallString<128> ShortResult;
   ASSERT_FALSE(windows::makeLong(Short, ShortResult));
   fs::UniqueID ShortID1, ShortID2;
@@ -2568,7 +2587,7 @@ TEST_F(FileSystemTest, makeLong) {
   ASSERT_NO_ERROR(fs::getUniqueID(ShortResult, ShortID2));
   EXPECT_EQ(ShortID1, ShortID2);
 
-  // === Case 3: Short path greater than MAX_PATH, no prefix ===
+  // Case 3: Short path greater than MAX_PATH, no prefix.
   SmallString<128> MaxResult;
   ASSERT_FALSE(windows::makeLong(MaxShort, MaxResult));
   fs::UniqueID MaxID1, MaxID2;
@@ -2578,7 +2597,10 @@ TEST_F(FileSystemTest, makeLong) {
   EXPECT_FALSE(StringRef(MaxResult).starts_with(R"(\\?\)"))
       << "Expected unprefixed result, got: " << MaxResult;
 
-  // === Case 4: Short path greater than MAX_PATH, with prefix ===
+      
+  std::cout << "MaxResult: " << MaxResult.str().str() << "\n";
+
+  // Case 4: Short path greater than MAX_PATH, with prefix.
   SmallString<128> MaxPrefixedResult;
   ASSERT_FALSE(windows::makeLong(MaxShortWithPrefix, MaxPrefixedResult));
   fs::UniqueID MaxPrefixedID1, MaxPrefixedID2;
@@ -2587,6 +2609,9 @@ TEST_F(FileSystemTest, makeLong) {
   EXPECT_EQ(MaxPrefixedID1, MaxPrefixedID2);
   EXPECT_TRUE(StringRef(MaxPrefixedResult).starts_with(R"(\\?\)"))
       << "Expected prefixed result, got: " << MaxPrefixedResult;
+
+  
+      std::cout << "MaxPrefixedResult: " << MaxPrefixedResult.str().str() << "\n";
 
   // Cleanup
   ASSERT_NO_ERROR(fs::remove_directories(TestDirectory.str()));

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Windows/WindowsSupport.h"
+#include <fileapi.h>
 #include <windows.h>
 #include <winerror.h>
 #endif
@@ -2448,6 +2449,191 @@ TEST_F(FileSystemTest, widenPath) {
 #endif
 
 #ifdef _WIN32
+
+TEST_F(FileSystemTest, getVolumeRootFromPath) {
+  SmallVector<wchar_t, 128> Path16;
+
+  ASSERT_FALSE(sys::windows::UTF8ToUTF16(TestDirectory, Path16));
+
+  SmallVector<wchar_t, 128> VolumeRoot16;
+  ASSERT_FALSE(sys::windows::getVolumeRootFromPath(Path16, VolumeRoot16));
+
+  SmallString<128> VolumeRoot8;
+  ASSERT_FALSE(sys::windows::UTF16ToUTF8(VolumeRoot16.data(),
+                                         VolumeRoot16.size(), VolumeRoot8));
+
+  SmallString<128> ExpectedRoot(sys::path::root_name(TestDirectory));
+  ExpectedRoot += "\\";
+
+  EXPECT_EQ(VolumeRoot8, ExpectedRoot);
+}
+
+/// Resolves a UTF-16 path to its absolute form using GetFullPathNameW.
+/// Returns true on success and stores the result in `Result`.
+static bool getFullPath(llvm::SmallVectorImpl<wchar_t> &Path16,
+                        llvm::SmallVectorImpl<wchar_t> &Result) {
+  // Call GetFullPathNameW to get the required buffer size.
+  DWORD Len = ::GetFullPathNameW(Path16.data(), 0, nullptr, nullptr);
+  if (Len == 0)
+    return false;
+
+  // Call GetFullPathNameW to get the required buffer size.
+  Result.resize(Len);
+  DWORD FinalLen =
+      ::GetFullPathNameW(Path16.data(), Len, Result.data(), nullptr);
+  return FinalLen > 0 && FinalLen < Len;
+}
+
+/// Checks whether short (8.3) names are enabled for the volume containing the
+/// given UTF-8 path.
+static bool isShortNameEnabledForPath(llvm::StringRef Path8) {
+  llvm::SmallVector<wchar_t, 128> Path16;
+  if (windows::widenPath(Path8, Path16))
+    return false;
+
+  SmallVector<wchar_t, 128> FullPath16;
+  if (!getFullPath(Path16, FullPath16))
+    return false;
+
+  // Get volume root.
+  llvm::SmallVector<wchar_t, 128> VolumeRoot16;
+  if (std::error_code EC =
+          windows::getVolumeRootFromPath(FullPath16, VolumeRoot16))
+    return false;
+
+  // Attempt to load AreShortNamesEnabled dynamically (it's avalible only on
+  // some versions of Windows).
+  using AreShortNamesEnabledFn = BOOL(WINAPI *)(HANDLE, BOOL *);
+  auto Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
+  if (!Kernel32)
+    return false;
+
+  auto *FnPtr =
+      reinterpret_cast<AreShortNamesEnabledFn>(reinterpret_cast<void *>(
+          ::GetProcAddress(Kernel32, "AreShortNamesEnabled")));
+  if (!FnPtr)
+    return false;
+
+  // Open the volume root for querying.
+  HANDLE VolumeHandle = ::CreateFileW(
+      VolumeRoot16.data(), GENERIC_READ,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+      OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+
+  if (VolumeHandle == INVALID_HANDLE_VALUE)
+    return false;
+
+  BOOL Enabled = FALSE;
+  bool Success = FnPtr(static_cast<void *>(VolumeHandle), &Enabled);
+  ::CloseHandle(VolumeHandle);
+
+  return Success && Enabled;
+}
+
+/// Returns the 8.3 path for the given UTF-8 path, or an empty string
+/// on failure. Uses Win32 GetShortPathNameW.
+static std::string getShortPathUtf8(llvm::StringRef Path8) {
+  using namespace llvm;
+
+  // Convert UTF-8 to UTF-16
+  SmallVector<wchar_t, MAX_PATH> Path16;
+  if (std::error_code EC = sys::windows::widenPath(Path8, Path16))
+    return {};
+
+  // Get required buffer size for short path (includes null terminator)
+  DWORD Required = ::GetShortPathNameW(Path16.data(), nullptr, 0);
+  if (Required == 0)
+    return {};
+
+  SmallVector<wchar_t, MAX_PATH> ShortPath;
+  ShortPath.resize_for_overwrite(Required);
+
+  DWORD Written =
+      ::GetShortPathNameW(Path16.data(), ShortPath.data(), Required);
+  if (Written == 0 || Written >= Required)
+    return {};
+
+  ShortPath.truncate(Written);
+
+  SmallString<128> Utf8Result;
+  if (std::error_code EC = sys::windows::UTF16ToUTF8(
+          ShortPath.data(), ShortPath.size(), Utf8Result))
+    return {};
+
+  return std::string(Utf8Result);
+}
+
+static std::string stripPrefix(llvm::StringRef P) {
+  if (P.starts_with(R"(\\?\UNC\)"))
+    return "\\" + P.drop_front(8).str();
+  if (P.starts_with(R"(\\?\)"))
+    return P.drop_front(4).str();
+  return P.str();
+}
+
+TEST_F(FileSystemTest, makeLong) {
+  if (!isShortNameEnabledForPath(TestDirectory.str()))
+    GTEST_SKIP() << "Short names not enabled on volume.";
+
+  // Get a short-path version of the test directory
+  std::string Short8 = getShortPathUtf8(TestDirectory);
+  ASSERT_FALSE(Short8.empty())
+      << "Expected short path form for test directory.";
+
+  // Setup: Create a path where even if all components were reduced to short
+  //        form (typically 8 characters e.g. 123456~1) the total length would
+  //        exceed MAX_PATH.
+  constexpr const char *OneDir = "\\123456789"; // >8 chars
+  const size_t NLevels = (MAX_PATH / 8) + 1;
+  SmallString<MAX_PATH * 2> Long(TestDirectory);
+  for (size_t I = 0; I < NLevels; ++I)
+    Long.append(OneDir);
+
+  ASSERT_NO_ERROR(fs::create_directories(Long));
+  std::string LongShort8WithPrefix = getShortPathUtf8(Long);
+  ASSERT_TRUE(StringRef(LongShort8WithPrefix).starts_with(R"(\\?\)"))
+      << "Expected prefixed short path, got: " << LongShort8WithPrefix;
+
+  std::string LongShort8 = stripPrefix(LongShort8WithPrefix);
+
+  // === Case 1: Non-existent short path should fail ===
+  SmallString<128> NoExist("No Existy~1 Path");
+  SmallString<128> NoExistResult;
+  EXPECT_TRUE(windows::makeLong(NoExist, NoExistResult));
+  EXPECT_TRUE(NoExistResult.empty());
+
+  // === Case 2: Short path that exists, no prefix ===
+  SmallString<128> ShortResult;
+  ASSERT_FALSE(windows::makeLong(Short8, ShortResult));
+  fs::UniqueID ShortID1, ShortID2;
+  ASSERT_NO_ERROR(fs::getUniqueID(Short8, ShortID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(ShortResult, ShortID2));
+  EXPECT_EQ(ShortID1, ShortID2);
+
+  // === Case 3: Long short path (no prefix) ===
+  SmallString<128> LongResult;
+  ASSERT_FALSE(windows::makeLong(LongShort8, LongResult));
+  fs::UniqueID LongID1, LongID2;
+  ASSERT_NO_ERROR(fs::getUniqueID(LongShort8, LongID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(LongResult, LongID2));
+  EXPECT_EQ(LongID1, LongID2);
+  EXPECT_FALSE(StringRef(LongResult).starts_with(R"(\\?\)"))
+      << "Expected unprefixed result, got: " << LongResult;
+
+  // === Case 4: Long short path with prefix ===
+  SmallString<128> LongPrefixedResult;
+  ASSERT_FALSE(windows::makeLong(LongShort8WithPrefix, LongPrefixedResult));
+  fs::UniqueID LongPrefixedID1, LongPrefixedID2;
+  ASSERT_NO_ERROR(fs::getUniqueID(LongShort8WithPrefix, LongPrefixedID1));
+  ASSERT_NO_ERROR(fs::getUniqueID(LongPrefixedResult, LongPrefixedID2));
+  EXPECT_EQ(LongPrefixedID1, LongPrefixedID2);
+  EXPECT_TRUE(StringRef(LongPrefixedResult).starts_with(R"(\\?\)"))
+      << "Expected prefixed result, got: " << LongPrefixedResult;
+
+  // Cleanup
+  ASSERT_NO_ERROR(fs::remove(Long));
+}
+
 // Windows refuses lock request if file region is already locked by the same
 // process. POSIX system in this case updates the existing lock.
 TEST_F(FileSystemTest, FileLocker) {


### PR DESCRIPTION
8.3-style short-form paths (e.g., C:\PROGRA~1) can cause inconsistencies or
failures on remote machines during distributed linking. Such paths may not
resolve correctly or may differ between systems. Short-form paths are
relatively common - for example, clang often writes temporary object files
to %TEMP%, which is frequently a short-form path.

We are aware of at least one distribution system (SN-DBS) affected by this,
and we expect that many (perhaps all) distribution systems may encounter
similar issues.

This patch ensures that all Windows paths used for DTLTO in ELF LLD are
normalized to their long form using GetLongPathNameW. This avoids ambiguity
and improves portability across distribution environments.

For testing, AreShortNamesEnabled is used to detect whether 8.3 path support
is enabled on the current volume. However, this API is only available on
Windows 11. As a result, the related tests are skipped on earlier versions
of Windows due to the lack of a reliable alternative for feature detection.
